### PR TITLE
PoC - Extract Change - Use full path

### DIFF
--- a/cli/internal/docs/extractChange.go
+++ b/cli/internal/docs/extractChange.go
@@ -47,7 +47,7 @@ func ExtractChange(system *config.System, head string, base string, db *sql.DB) 
 				slog.Debug("docs.ExtractChange could not retrieve action for diff", "error", err, "diff", diff)
 				return err
 			}
-			from, to, err := diff.Files()
+			_, to, err := diff.Files()
 			if err != nil {
 				slog.Debug("docs.ExtractChange could not retrieve files for diff", "error", err, "diff", diff)
 				return err
@@ -56,18 +56,18 @@ func ExtractChange(system *config.System, head string, base string, db *sql.DB) 
 			case merkletrie.Insert:
 				fallthrough
 			case merkletrie.Modify:
-				if glob.Match(to.Name) {
-					slog.Debug("docs.ExtractChange inserting document", "document", to.Name, "action", action)
+				if glob.Match(diff.To.Name) {
+					slog.Debug("docs.ExtractChange inserting document", "document", diff.To.Name, "action", action)
 					bytes, err := repo.GetBlobBytes(to.Blob)
 					if err != nil {
 						slog.Debug("docs.ExtractChange could not retrieve blob from diff", "error", err)
 						return err
 					}
 					err = sqlite.InsertChangeDocument(sqlite.ChangeDocument{
-						ID:              to.Name,
+						ID:              diff.To.Name,
 						DocumentationID: documentationId,
 						SystemID:        system.ID,
-						RelativePath:    to.Name,
+						RelativePath:    diff.To.Name,
 						Format:          d.Type,
 						Action:          action.String(),
 						RawData:         string(bytes),
@@ -88,13 +88,13 @@ func ExtractChange(system *config.System, head string, base string, db *sql.DB) 
 					}
 				}
 			case merkletrie.Delete:
-				if glob.Match(from.Name) {
-					slog.Debug("docs.ExtractChange inserting document", "document", from.Name, "action", action)
+				if glob.Match(diff.From.Name) {
+					slog.Debug("docs.ExtractChange inserting document", "document", diff.From.Name, "action", action)
 					err = sqlite.InsertChangeDocument(sqlite.ChangeDocument{
-						ID:              from.Name,
+						ID:              diff.From.Name,
 						DocumentationID: documentationId,
 						SystemID:        system.ID,
-						RelativePath:    from.Name,
+						RelativePath:    diff.From.Name,
 						Format:          d.Type,
 						Action:          action.String(),
 						RawData:         "",


### PR DESCRIPTION
# Purpose
The purpose of this PR is to resolve an issue where document and file IDs and relative paths were calculated from the directory of the file rather than from the root of the directory. This resolves that issue and brings the outcome into conformity with the plan and outcome specified in https://github.com/appgardenstudios/hyaline/issues/7.

# Changes
* Use the diff from/to name instead of the from/to file name when extracting changes.

# Testing
See #14 and make sure that one of the files added/modified/removed is in a sub-directory