### PR TITLE
PoC - Check with Action (current + change) - Fix section exists logic

### DIFF
--- a/cli/internal/rule/sectionExists.go
+++ b/cli/internal/rule/sectionExists.go
@@ -124,7 +124,7 @@ func RunSectionExists(id string, description string, options SectionExistsOption
 		result.Severity = options.Severity
 		result.Message = fmt.Sprintf("The section '%s' must exist in '%s'%s.", options.Section, options.Document, sectionExistsWithoutTodos(options.AllowTodos))
 		if recommendAction {
-			action, err := recommend.SectionExists(true, options.Section, options.Document, system, current, change, llmOpts)
+			action, err := recommend.SectionExists(false, options.Section, options.Document, system, current, change, llmOpts)
 			if err != nil {
 				slog.Debug("rule.RunSectionExists could not generate recommendation", "error", err)
 			} else {
@@ -140,7 +140,7 @@ func RunSectionExists(id string, description string, options SectionExistsOption
 		result.Severity = options.Severity
 		result.Message = fmt.Sprintf("The section '%s' in '%s' must contain text%s.", options.Section, options.Document, sectionExistsWithoutTodos(options.AllowTodos))
 		if recommendAction {
-			action, err := recommend.SectionExists(false, options.Section, options.Document, system, current, change, llmOpts)
+			action, err := recommend.SectionExists(true, options.Section, options.Document, system, current, change, llmOpts)
 			if err != nil {
 				slog.Debug("rule.RunSectionExists could not generate recommendation", "error", err)
 			} else {


### PR DESCRIPTION
# Purpose
The purpose of this PR is to fix the section exists logic so that it properly says `create` vs `add content to` the relevant section based on if the section exists or not as described in https://github.com/appgardenstudios/hyaline/issues/9.

# Changes
* Fix the section exists flags to match what each statement is checking for

# Testing
See #17 for details.