### PR TITLE
Open Beta - download - build - ignore dist

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -16,3 +16,6 @@ hyaline-e2e
 e2e/_output/*
 generated-config.yml
 results.json
+
+# Release artifacts
+dist/


### PR DESCRIPTION
# Purpose
The purpose of this change is to ignore the built artifacts that were created in https://github.com/appgardenstudios/hyaline/issues/94.

# Changes
* Add `dist/` to the .gitignore file

# Testing
`make release` and then ensure git does not pickup files in the dist directory