### PR TITLE
Open Beta - docs - document - Reference for Results

### DIFF
--- a/www/content/docs/reference/results.md
+++ b/www/content/docs/reference/results.md
@@ -77,8 +77,8 @@ A list of fields, their types, and a description of each.
 ### Checks
 The list of available checks, what cli option is required to perform the chck (if any), and a description of the check
 
-| Check | Option | Description |
-|-------|--------|-------------|
+| Check | CLI Option | Description |
+|-------|------------|-------------|
 | COMPLETE | --check-completeness | If the document or section contents are complete |
 | DESIRED_DOCUMENT_EXISTS | (none) | If there is a corresponding document or section in the configuration |
 | MATCHES_PURPOSE | --check-purpose | If the document or section contents match the stated purpose in the config |


### PR DESCRIPTION
# Purpose
The purpose of this change is to document the reference of the results output for hyaline check current and hyaline check change per https://github.com/appgardenstudios/hyaline/issues/114.

# Changes
* Created `www/content/docs/reference/results.md`

# Testing
View `www/content/docs/reference/results.md` in a markdown previewer.