### PR TITLE
Open Beta - download - www

### DIFF
--- a/cli/scripts/assets/release-notes.md
+++ b/cli/scripts/assets/release-notes.md
@@ -1,0 +1,7 @@
+## Before you download or use Hyaline, a few things:
+
+- Hyaline is in an open beta that is currently free. The price and licensing structure for Hyaline has not been finalized. If you have thoughts or ideas feel free to contact [john@hyaline.dev](mailto:john@hyaline.dev).
+- Hyaline uses an LLM. While Hyaline does its best to be efficient and cost sensitive, your configuration and use of Hyaline will dictate how many LLM calls Hyaline will make. Please read the [https://hyaline.dev/documentation](documentation) to understand how Hyaline works so you know what it will do. You take full responsibility for the costs incurred by your use of Hyaline.
+- Hyaline is intended to assist in the identification and drafting of documentation, not to replace the sound judgment and craftsmanship of your developers and team members. Use it well.
+
+By continuing, you acknowledge that you understand the terms above.

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -7,14 +7,14 @@ rm -f ./dist/*
 # Build and test hyaline
 make build
 make test
-make e2e
+# make e2e
 
 # Make sure we are on the main branch
-CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-if [ "$CURRENT_BRANCH" != "main" ]; then
-  echo "Must be on main branch to release."
-  exit 1
-fi
+# CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+# if [ "$CURRENT_BRANCH" != "main" ]; then
+#   echo "Must be on main branch to release."
+#   exit 1
+# fi
 
 # Calculate tag YYYY-MM-DD-HASH
 DATE=`git log -n1 --pretty='%cd' --date=format:'%Y-%m-%d'`
@@ -59,4 +59,4 @@ git tag $TAG
 git push origin $TAG
 
 # Create Draft Release (will print link to release when done)
-gh release create $TAG --draft --verify-tag --fail-on-no-commits --generate-notes --latest ./dist/*.zip
+gh release create $TAG --draft --verify-tag --fail-on-no-commits --generate-notes --notes-file ./scripts/assets/release-notes.md --latest ./dist/*.zip

--- a/cli/scripts/release.sh
+++ b/cli/scripts/release.sh
@@ -7,14 +7,14 @@ rm -f ./dist/*
 # Build and test hyaline
 make build
 make test
-# make e2e
+make e2e
 
 # Make sure we are on the main branch
-# CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
-# if [ "$CURRENT_BRANCH" != "main" ]; then
-#   echo "Must be on main branch to release."
-#   exit 1
-# fi
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "Must be on main branch to release."
+  exit 1
+fi
 
 # Calculate tag YYYY-MM-DD-HASH
 DATE=`git log -n1 --pretty='%cd' --date=format:'%Y-%m-%d'`

--- a/www/content/download.html
+++ b/www/content/download.html
@@ -1,0 +1,66 @@
+---
+title: "Download Hyaline"
+---
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="max-w-3xl mx-auto">
+    <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-12">
+      Download Hyaline
+    </h1>
+
+    <div class="space-y-8 text-lg text-gray-700 leading-relaxed">
+      <section>
+        <p class="mb-4 font-bold">
+          Before you download or use Hyaline, a few things:
+        </p>
+
+        <ul class="list-disc pl-8 space-y-2 mb-4">
+          <li>
+            Hyaline is in an open beta that is currently free. The price and
+            licensing structure for Hyaline has not been finalized. If you have
+            thoughts or ideas feel free to contact
+            <a
+              href="mailto:john@hyaline.dev"
+              class="text-blue-600 underline hover:text-blue-700"
+              >john@hyaline.dev</a
+            >.
+          </li>
+          <li>
+            Hyaline uses an LLM. While Hyaline does its best to be efficient and
+            cost sensitive, your configuration and use of Hyaline will dictate
+            how many LLM calls Hyaline will make. Please read the
+            <a
+              href="/documentation"
+              class="text-blue-600 underline hover:text-blue-700"
+              >documentation</a
+            >
+            to understand how Hyaline works so you know what it will do. You
+            take full responsibility for the costs incurred by your use of
+            Hyaline.
+          </li>
+          <li>
+            Hyaline is intended to assist in the identification and drafting of
+            documentation, not to replace the sound judgment and craftsmanship
+            of your developers and team members. Use it well.
+          </li>
+        </ul>
+      </section>
+
+      <section class="pt-4">
+        <div class="bg-blue-100 rounded-lg p-8">
+          <p class="text-gray-600 text-lg">
+            By continuing, you acknowledge that you understand the terms above.
+            <a
+              href="https://github.com/appgardenstudios/hyaline/releases"
+              class="text-blue-600 underline hover:text-blue-700 font-semibold"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Proceed to downloads →
+            </a>
+          </p>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/www/content/download.html
+++ b/www/content/download.html
@@ -52,7 +52,7 @@ title: "Download Hyaline"
             By continuing, you acknowledge that you understand the terms above.
             <a
               href="https://github.com/appgardenstudios/hyaline/releases"
-              class="text-blue-600 underline hover:text-blue-700 font-semibold"
+              class="text-blue-700 underline font-semibold"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -114,7 +114,7 @@
 
     <main>{{ block "main" . }} {{ end }}</main>
 
-    <footer class="bg-gray-100 py-8 bg-white">
+    <footer class="bg-gray-100 py-8 bg-white border-t border-gray-200">
       <div class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center">
           <p class="text-gray-600">


### PR DESCRIPTION
# Purpose
The purpose of this change is to add a download page where a user can be notified of disclaimers and then proceed to the releases page in GH to download Hyaline.

# Changes
- New `/download` page created with disclaimer and link to releases page
- Disclaimer included in release notes

# Testing
1. Install prerequisites: `brew install hugo tailwindcss` (macOS)
2. Navigate to `www/` directory
3. Run `make` to start development server
4. View `http://localhost/download` and confirm the disclaimer content appears, along with the link to release notes

Testing of the release notes can also be done by running `make release` from the `cli` directory. However, this will create a tag and release that will need to be deleted. I did do this in order to make sure things worked properly