### PR TITLE
Open Beta - changes - use config.PathIsIncluded()

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -27,6 +27,8 @@ HYALINE_SSH_PEM= #A SSH key that has pull access to github.com/appgardenstudios/
 HYALINE_SSH_PASSWORD= #A password for the PEM above (blank if PEM is not password protected)
 ```
 
+Note that you must have the `github.com/appgardenstudios/hyaline-example` repository cloned as a sibling directory to hyaline for some of the launch configurations to work properly.
+
 ## Testing
 Unit tests are run with `make test`, and there are e2e tests that invoke the actual hyaline binary that you can run with `make e2e`.
 

--- a/cli/_example/config.yml
+++ b/cli/_example/config.yml
@@ -108,7 +108,7 @@ systems:
             branch: main
             clone: true
             auth:
-              type: http
+              type: ssh
               options:
                 user: git
                 pem: ${HYALINE_SSH_PEM}

--- a/cli/internal/repo/getRepo.go
+++ b/cli/internal/repo/getRepo.go
@@ -61,14 +61,14 @@ func GetRepo(options config.ExtractorOptions) (r *git.Repository, err error) {
 			}
 			r, err = git.PlainClone(absPath, false, cloneOptions)
 			if err != nil {
-				slog.Debug("repo.GetRepo could clone repo", "error", err, "path", options.Path, "repo", options.Repo)
+				slog.Debug("repo.GetRepo could not clone repo to disk", "error", err, "path", options.Path, "repo", options.Repo)
 				return
 			}
 		} else {
 			// Clone into a memory fs
 			r, err = git.Clone(memory.NewStorage(), nil, cloneOptions)
 			if err != nil {
-				slog.Debug("repo.GetRepo could clone repo", "error", err, "path", options.Path, "repo", options.Repo)
+				slog.Debug("repo.GetRepo could not clone repo to memory", "error", err, "path", options.Path, "repo", options.Repo)
 				return
 			}
 		}


### PR DESCRIPTION
# Purpose
Use config.PathIsIncluded() everywhere that include and exclude paths are used. https://github.com/appgardenstudios/hyaline/issues/130

# Changes
- Replaced duplicated code with `config.PathIsIncluded()`
- Added a note to the cli/README.md to help people run the launch configs successfully
- Corrected a typo in `cli/_example/config.yml` that was causing the launch configs to fail
- Improved logging in `cli/internal/repo/getRepo.go` to be clearer about what happens in error scenarios

# Testing
After cloning down the repository, run unit and e2e tests to ensure they pass.