### PR TITLE
Open Beta - changes - output empty array instead of null in update pr comment

### DIFF
--- a/cli/e2e/_golden/update-pr-empty.json
+++ b/cli/e2e/_golden/update-pr-empty.json
@@ -1,0 +1,5 @@
+{
+  "sha": "b4c5c73",
+  "recommendations": [],
+  "rawData": "\u003c![CDATA[ [] ]]\u003e"
+}

--- a/cli/e2e/_input/update-pr-empty/config.yml
+++ b/cli/e2e/_input/update-pr-empty/config.yml
@@ -1,0 +1,2 @@
+github:
+  token: ${HYALINE_GITHUB_PAT}

--- a/cli/e2e/_input/update-pr-empty/recommendations.json
+++ b/cli/e2e/_input/update-pr-empty/recommendations.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": []
+}

--- a/cli/e2e/updatePREmpty_test.go
+++ b/cli/e2e/updatePREmpty_test.go
@@ -1,0 +1,44 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestUpdatePREmpty(t *testing.T) {
+	goldenPath := "./_golden/update-pr-empty.json"
+	outputPath := fmt.Sprintf("./_output/update-pr-empty-%d.json", time.Now().UnixMilli())
+	args := []string{
+		"update", "pr",
+		"--config", "./_input/update-pr-empty/config.yml",
+		"--pull-request", "appgardenstudios/hyaline-example/1",
+		"--sha", "b4c5c73",
+		"--recommendations", "./_input/update-pr-empty/recommendations.json",
+		"--output", outputPath,
+	}
+
+	stdOutStdErr, err := runBinary(args, t)
+	t.Log(string(stdOutStdErr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean up the comment we just added
+	// gh -R appgardenstudios/hyaline-example pr comment 1 --delete-last --yes
+	cmd := exec.Command("gh", "-R", "appgardenstudios/hyaline-example", "pr", "comment", "1", "--delete-last", "--yes")
+	cmd.Env = os.Environ()
+	stdOutStdErr, err = cmd.CombinedOutput()
+	t.Log(string(stdOutStdErr))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *update {
+		updateGolden(goldenPath, outputPath, t)
+	}
+
+	compareFiles(goldenPath, outputPath, t)
+}

--- a/cli/internal/action/updatePR.go
+++ b/cli/internal/action/updatePR.go
@@ -264,7 +264,7 @@ func newRecMatchesExisting(newRec *CheckChangeOutputEntry, existingRec *UpdatePR
 
 func updatePRAddComment(sha string, recommendations []CheckChangeOutputEntry, pr string, token string) (*UpdatePRComment, error) {
 	// Format recs
-	var recs []UpdatePRCommentRecommendation
+	recs := []UpdatePRCommentRecommendation{}
 	for _, rec := range recommendations {
 		recs = append(recs, UpdatePRCommentRecommendation{
 			Checked:  rec.Changed,


### PR DESCRIPTION
# Purpose
The purpose of this change is to fix the output format when there are no recommendations in update PR comments. Instead of outputting `null`, the system now outputs an empty array `[]` in both the CDATA block and JSON output. This addresses issue https://github.com/appgardenstudios/hyaline/issues/138.

# Changes
- Modified `updatePRAddComment` function in `cli/internal/action/updatePR.go` to initialize an empty slice instead of using `nil`
- Added comprehensive e2e test case `TestUpdatePREmpty` to verify empty recommendations behavior
- Created test input files and golden file for the new test case
- Verified that both CDATA block and JSON output now contain `[]` instead of `null`

# Testing
- Run `make test` to verify unit tests pass
- Run `go test ./e2e/... -run "TestUpdate"` to verify all update-related e2e tests pass
- Check the generated golden file at `cli/e2e/_golden/update-pr-empty.json` to see the correct output format
- The fix can be manually tested by running the CLI with empty recommendations and verifying the output contains `<\![CDATA[ [] ]]>` instead of `<\![CDATA[ null ]]>`