### PR TITLE
Open Beta - docs - fix documentation paths in hyaline config

### DIFF
--- a/hyaline.yml
+++ b/hyaline.yml
@@ -71,7 +71,7 @@ systems:
           include:
             - "www/content/documentation/**/*.md"
         documents:
-          - name: www/content/documentation/reference/cli.md
+          - name: www/content/documentation/04-reference/02-cli.md
             purpose: Document the usage and options for every Hyaline command
             required: true
             updateIf:
@@ -111,7 +111,7 @@ systems:
                   - name: update pr
                     purpose: Document the usage and options for the update pr command
                     required: true
-          - name: www/content/documentation/reference/config.md
+          - name: www/content/documentation/04-reference/01-config.md
             purpose: Document every option in the Hyaline configuration file
             required: true
             sections:
@@ -125,7 +125,7 @@ systems:
                 ignore: true
               - name: Common Documents
                 ignore: true
-          - name: www/content/documentation/reference/data-set.md
+          - name: www/content/documentation/04-reference/03-data-set.md
             purpose: Document the sqlite schema used by Hyaline to store current and change data sets
             required: true
             sections:
@@ -135,7 +135,7 @@ systems:
                 ignore: true
               - name: Enums
                 ignore: true
-          - name: www/content/documentation/reference/results.md
+          - name: www/content/documentation/04-reference/04-results.md
             required: true
             sections:
               - name: Overview


### PR DESCRIPTION
# Purpose
The purpose of this change is to correct the documentation paths in the hyaline config based on the path changes that were made in https://github.com/appgardenstudios/hyaline/issues/25.

# Changes
- Updated hyaline.yml with the correct documentation paths

# Testing
Verify that the paths are correct and that hyaline commands like check change use the proper paths.