### PR TITLE
Open Beta - changes - fix section headings

### DIFF
--- a/www/content/documentation/04-reference/04-results.md
+++ b/www/content/documentation/04-reference/04-results.md
@@ -60,7 +60,7 @@ This documents the results produced by the `check current` and `check change` co
 }
 ```
 
-## Fields
+### Fields
 A list of fields, their types, and a description of each.
 
 | Field | Type | Description |
@@ -76,7 +76,7 @@ A list of fields, their types, and a description of each.
 | results[n].result | String | The result of the check |
 | results[n].message | String | The message (may be an empty string) |
 
-## Checks
+### Checks
 The list of available checks, what cli option is required to perform the chck (if any), and a description of the check
 
 | Check | CLI Option | Description |
@@ -86,7 +86,7 @@ The list of available checks, what cli option is required to perform the chck (i
 | MATCHES_PURPOSE | --check-purpose | If the document or section contents match the stated purpose in the config |
 | REQUIRED | (none) | If the document or section is present if marked as required in the config |
 
-## Results
+### Results
 The list of possible results and a description of the result
 
 | Check | Description |
@@ -118,7 +118,7 @@ The list of possible results and a description of the result
 }
 ```
 
-## Fields
+### Fields
 A list of fields, their types, and a description of each.
 
 | Field | Type | Description |


### PR DESCRIPTION
# Purpose
The purpose of this change is to correct the section headings in the `results.md` documentation to ensure section headings are unique within their nesting level. This is now especially important since we are enforcing uniqueness with primary keys. https://github.com/appgardenstudios/hyaline/issues/157

# Changes
- Correct the section heading levels for `results.md` to properly nest

# Testing
Run www and view http://localhost:1313/documentation/reference/results/. Confirm that the headings are nested properly