### PR TITLE
Release - CLI Updates

### DIFF
--- a/cli/cmd/hyaline.go
+++ b/cli/cmd/hyaline.go
@@ -14,18 +14,23 @@ var Version = "unknown"
 
 var usage = "Maintain Your Documentation - Find, Fix, and Prevent Documentation Issues."
 
-var betaNote = "Note: Hyaline is currently in an open beta. As such, this software is only licensed for evaluation and use until the open beta period ends."
+var licenseNote = "Note: This software requires a license for any purpose other than evaluation or demonstration. By using this software you attest that you are either 1) using Hyaline for evaluation or demonstration purposes or 2) that you have a current and valid license to use Hyaline."
 
 func main() {
+	// Configure logger
 	var logLevel = new(slog.LevelVar)
 	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})
 	slog.SetDefault(slog.New(h))
 
+	// Output license information
+	fmt.Fprintf(os.Stderr, "%s\n\n", licenseNote)
+
+	// Configure app
 	app := &cli.App{
 		Name:  "hyaline",
-		Usage: fmt.Sprintf("%s\n%s", usage, betaNote),
+		Usage: usage,
 		Action: func(*cli.Context) error {
-			fmt.Printf("%s\n%s\n", usage, betaNote)
+			fmt.Printf("%s\n", usage)
 			return nil
 		},
 		Flags: []cli.Flag{
@@ -35,7 +40,8 @@ func main() {
 			},
 		},
 		Commands: []*cli.Command{
-			hyaline.Version(Version, betaNote),
+			hyaline.Version(Version),
+			hyaline.License(),
 			hyaline.Check(logLevel),
 			hyaline.Extract(logLevel),
 			hyaline.Generate(logLevel),
@@ -45,6 +51,7 @@ func main() {
 		},
 	}
 
+	// Run the app
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/cli/cmd/hyaline.go
+++ b/cli/cmd/hyaline.go
@@ -14,7 +14,7 @@ var Version = "unknown"
 
 var usage = "Maintain Your Documentation - Find, Fix, and Prevent Documentation Issues."
 
-var licenseNote = "Note: This software requires a license for any purpose other than evaluation or demonstration. By using this software you attest that you are either 1) using Hyaline for evaluation or demonstration purposes or 2) that you have a current and valid license to use Hyaline."
+var licenseNote = "Note: This software requires a license for any purpose other than evaluation or demonstration. By using this software you attest that you are either 1) using Hyaline for evaluation or demonstration purposes or 2) you have a current and valid license to use Hyaline."
 
 func main() {
 	// Configure logger

--- a/cli/cmd/hyaline/license.go
+++ b/cli/cmd/hyaline/license.go
@@ -1,0 +1,21 @@
+package hyaline
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+func License() *cli.Command {
+	return &cli.Command{
+		Name:  "license",
+		Usage: "Print out license information",
+		Action: func(cCtx *cli.Context) error {
+			fmt.Printf("Copyright %d App Garden Studios, LLC\n\n", time.Now().Year())
+			fmt.Print("All Rights Reserved\n\n")
+			fmt.Print("THE CONTENTS OF THIS PROJECT ARE PROPRIETARY AND CONFIDENTIAL. UNAUTHORIZED COPYING, TRANSFER, OR REPRODUCTION OF THIS PROJECT VIA ANY MEDIUM IS STRICTLY PROHIBITED.\n")
+			return nil
+		},
+	}
+}

--- a/cli/cmd/hyaline/version.go
+++ b/cli/cmd/hyaline/version.go
@@ -6,12 +6,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func Version(version string, betaNote string) *cli.Command {
+func Version(version string) *cli.Command {
 	return &cli.Command{
 		Name:  "version",
 		Usage: "Print out the current version",
 		Action: func(cCtx *cli.Context) error {
-			fmt.Printf("%s\n%s\n", version, betaNote)
+			fmt.Printf("%s\n", version)
 			return nil
 		},
 	}

--- a/cli/scripts/assets/release-notes.md
+++ b/cli/scripts/assets/release-notes.md
@@ -1,7 +1,2 @@
-## Before you download or use Hyaline, a few things:
-
-- Hyaline is in an open beta that is currently free. The price and licensing structure for Hyaline has not been finalized. If you have thoughts or ideas feel free to contact [john@hyaline.dev](mailto:john@hyaline.dev).
-- Hyaline uses an LLM. While Hyaline does its best to be efficient and cost sensitive, your configuration and use of Hyaline will dictate how many LLM calls Hyaline will make. Please read the [https://hyaline.dev/documentation](documentation) to understand how Hyaline works so you know what it will do. You take full responsibility for the costs incurred by your use of Hyaline.
-- Hyaline is intended to assist in the identification and drafting of documentation, not to replace the sound judgment and craftsmanship of your developers and team members. Use it well.
-
-By continuing, you acknowledge that you understand the terms above.
+## Note:
+This software requires a license for any purpose other than evaluation or demonstration. By downloading this software you attest that you are either 1) using Hyaline for evaluation or demonstration purposes or 2) that you have a current and valid license to use Hyaline.

--- a/cli/scripts/assets/release-notes.md
+++ b/cli/scripts/assets/release-notes.md
@@ -1,2 +1,2 @@
 ## Note:
-This software requires a license for any purpose other than evaluation or demonstration. By downloading this software you attest that you are either 1) using Hyaline for evaluation or demonstration purposes or 2) that you have a current and valid license to use Hyaline.
+This software requires a license for any purpose other than evaluation or demonstration. By downloading this software you attest that you are either 1) using Hyaline for evaluation or demonstration purposes or 2) you have a current and valid license to use Hyaline.


### PR DESCRIPTION
# Purpose
The purpose of this change is to update the CLI to add license information and remove open beta references as described in https://github.com/appgardenstudios/hyaline/issues/167.

# Changes
* Removed beta note
* Print out license note to stderr on program start
* Added `hyaline license`
* Added license note to the release note(s)

<img width="950" alt="Screenshot 2025-07-03 at 7 27 13 AM" src="https://github.com/user-attachments/assets/708bc0a3-5be8-4850-8561-e0852deb20c6" />


# Testing
`make build` and then:
- `./hyaline`
- `./hyaline version`
- `./hyaline license`

**Note**: You will need to be on the main branch or edit the release script to test the release notes change.