### PR TITLE
Product and Process Support - MCP - v1 documentation

### DIFF
--- a/contributing/how-to/add-documentation-to-www.md
+++ b/contributing/how-to/add-documentation-to-www.md
@@ -4,62 +4,52 @@ This guide explains how to add new documentation to the Hyaline website at [`/ww
 
 ## Adding Documentation
 
-### 1. File Naming and Ordering
+### 1. Table of Contents Configuration
 
-Files use numbered prefixes to control their order in navigation. Example:
+The documentation table of contents is controlled by the `www/data/documentation_toc.yml` file. This file defines the structure and order of documentation pages.
 
+Example structure:
+```yaml
+items:
+  - title: Overview
+    url: /documentation-v1/overview # an item can have a link
+  - title: How To # an item does not have to have a link
+    items: # an item can have sub-items
+      - title: Install the CLI
+        url: /documentation-v1/how-to/install-cli
+      - title: Run the CLI
+        url: /documentation-v1/how-to/run-cli
+  - title: Reference
+    items:
+      - title: CLI
+        url: /documentation-v1/reference/cli
+  - title: Roadmap
+    url: /documentation-v1/roadmap
 ```
-01-overview.md
-03-how-to/
-  01-install-cli.md
-  02-run-cli.md
-  03-check-pr.md
-04-explanation/
-  01-hyaline.md
-  02-extract-current.md
-```
 
-**To insert between existing files:**
-1. Add your file with the appropriate number
-2. Renumber all following files to maintain sequence
-
-Example: To add a new how-to guide between "Install CLI" and "Run CLI":
-- Add `02-my-new-guide.md`
-- Rename `02-run-cli.md` to `03-run-cli.md`
-- Rename `03-check-pr.md` to `04-check-pr.md`
+To add a new documentation page:
+1. Create the markdown file in the appropriate directory
+2. Add an entry in `documentation_toc.yml` with the title and URL
 
 ### 2. Directory Structure
 
-- **Top-level files** (like `01-overview.md`) appear at the root documentation level
-- **Subdirectories** automatically create categories in navigation
+- **Top-level files** (like `overview.md`) appear at the root documentation level
+- **Subdirectories** organize related documentation (e.g., `how-to/`, `reference/`)
 - **`_img/` directories** within categories store images for that category
 
 ### 3. Frontmatter
 
 **Frontmatter properties:**
-- `title`: Include category prefix for categorized docs (e.g., "How To: ", "Explanation: ")
-- `linkTitle`: For categorized docs, omit the category prefix (used in navigation)
+- `title`: The full title of the document
+- `description`: A brief description of the document
 - `purpose`: Brief description of the document's purpose
-- `url`: Custom URL path (removes numbered prefixes from URLs)
 
-
-Example For Top-Level Documents:
+Example:
 ```yaml
 ---
 title: Overview
-linkTitle: Overview
+description: "Learn how Hyaline helps teams maintain documentation"
 purpose: Give an overview of Hyaline and the documentation
-url: documentation/overview
----
-```
-
-Example For Categorized Documents:
-```yaml
----
-title: "How To: Install the Hyaline CLI"
-linkTitle: Install the Hyaline CLI
-purpose: Document how to install the Hyaline CLI
-url: documentation/how-to/install-cli
 ---
 ```
 
@@ -81,6 +71,6 @@ Example:
 
 Example:
 ```markdown
-[How To Install the CLI](./03-how-to/01-install-cli.md)
-[CLI Reference](../05-reference/02-cli.md)
+[How To Install the CLI](./how-to/install-cli.md)
+[CLI Reference](../reference/cli.md)
 ```

--- a/www/content/documentation-v1/_index.md
+++ b/www/content/documentation-v1/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Documentation"
+description: "Documentation to understand and use Hyaline effectively"
+sitemap:
+  disable: true
+---

--- a/www/content/documentation-v1/how-to/build-cli.md
+++ b/www/content/documentation-v1/how-to/build-cli.md
@@ -1,0 +1,50 @@
+---
+title: "How To: Build the Hyaline CLI"
+description: "Build the Hyaline CLI from source using Go toolchain for custom versions or architectures."
+purpose: Document how to build the Hyaline CLI
+sitemap:
+  disable: true
+---
+## Purpose
+Build the hyaline cli locally or on a remote machine.
+
+## Prerequisite(s)
+* [Go Toolchain](https://go.dev/) (version 1.24+)
+
+## Steps
+
+### 1. Clone/Checkout Hyaline Repo
+Ensure that the [Hyaline Repository](https://github.com/appgardenstudios/hyaline) is cloned and checked out to the version you wish to build.
+
+### 2. Determine the Version
+Hyaline uses the commit date and short hash to specify the version being build. This can be determined by running the following commands in the root of the repository with the desired commit checked out.
+
+```bash
+# Format: YYYY-MM-DD-HASH
+DATE=`git log -n1 --pretty='%cd' --date=format:'%Y-%m-%d'`
+HASH=`git rev-parse --short HEAD`
+VERSION="$DATE-$HASH"
+```
+
+### 3. Run Go Build
+Once the version is specified you can build hyaline using the following command (from the root of the repo):
+
+```bash
+$ go build -o ./dist/hyaline -ldflags="-X 'main.Version=$VERSION'" ./cmd/hyaline.go
+```
+
+You can specify the OS and architecture to use by setting the appropriate [GOOS/GOARCH environment variables](https://go.dev/doc/install/source#environment). For example, to build for the 64bit ARM version of MacOS:
+
+```bash
+$ GOOS=darwin GOARCH=arm64 go build -o ./dist/hyaline -ldflags="-X 'main.Version=$TAG'" ./cmd/hyaline.go
+```
+
+### 4. Test Executable
+Make sure you test that the resulting executable was built sucessfully and at the right version by running:
+
+```bash
+$ ./hyaline version
+```
+
+## Next Steps
+Visit [CLI Reference](../reference/cli.md).

--- a/www/content/documentation-v1/how-to/install-cli.md
+++ b/www/content/documentation-v1/how-to/install-cli.md
@@ -1,0 +1,32 @@
+---
+title: "How To: Install the Hyaline CLI"
+description: "How to download, install, and set up the Hyaline CLI on Linux, macOS, or Windows."
+purpose: Document how to install the Hyaline CLI
+sitemap:
+  disable: true
+---
+## Purpose
+Install the Hyaline CLI.
+
+## Prerequisite(s)
+* (none)
+
+## Steps
+
+### 1. Determine OS and Architecture
+Before starting the installation process you need to determine your operating system and architecture. Hyaline supports 64-bit Linux (`linux`), MacOS (`darwin`), and Windows (`windows`) operating systems for either `amd64` or `arm64` architectures (`amd64` only for Windows).
+
+### 2. Download Binary
+You can download the appropriate binary from the [Release Page](https://github.com/appgardenstudios/hyaline/releases) on GitHub. Just select the release you would like to use and get the link to the appropriate binary from the assets section.
+
+Alternatively you can use the following URL template: `https://github.com/appgardenstudios/hyaline/releases/download/{RELEASE}/hyaline-{OS}-{ARCH}.zip`.
+
+### 3. Unzip and Make Hyaline Executable
+Depending on your operating system you will need to do one or more of the following:
+
+* Unzip the downloaded executable
+* Make `hyaline` executable (if applicable)
+* Add `hyaline` to your PATH (if desired)
+
+## Next Steps
+Visit [How To Run the CLI](./run-cli.md) or the [CLI Reference](../reference/cli.md).

--- a/www/content/documentation-v1/how-to/run-cli.md
+++ b/www/content/documentation-v1/how-to/run-cli.md
@@ -1,0 +1,29 @@
+---
+title: "How To: Run the Hyaline CLI"
+description: "Run the Hyaline CLI."
+purpose: Document how to run the Hyaline CLI
+sitemap:
+  disable: true
+---
+## Purpose
+Run the hyaline cli locally or on a remote machine.
+
+## Prerequisite(s)
+* [Install the CLI](./install-cli.md)
+
+## Steps
+
+### 1. Ensure CLI is Installed
+Run `hyaline version` to ensure that the Hyaline CLI is installed and working properly.
+
+### 2. Get Path to Config
+Most commands require a hyaline configuration file. You will need to pass the path of the file in as the value of the `--config` commandline parameter. Either locate or create that configuration file now. For more information on the format of the configuration file please see the [Hyaline Config Reference](../reference/config.md).
+
+### 3. Export Env Vars (optional)
+Based on the contents of the configuration file above there may be one or more environment variables that need to be set before running Hyaline. You can find these in the config by looking for references like `${MY_VAR}`, which specifies that Hyaline should use the value of the environment variable `MY_VAR` for that key in the config.
+
+### 4. Execute the Command
+Now you can execute the hyaline command, passing in all of the required and (optionally) optional parameters. Please see [CLI Reference](../reference/cli.md) for a full list of commands and their associated options.
+
+## Next Steps
+Visit [CLI Reference](../reference/cli.md) or [How to build the CLI](./build-cli.md).

--- a/www/content/documentation-v1/overview.md
+++ b/www/content/documentation-v1/overview.md
@@ -1,0 +1,23 @@
+---
+title: Overview
+description: "Learn how Hyaline helps teams maintain documentation to build software products effectively."
+purpose: Give an overview of Hyaline and the documentation
+sitemap:
+  disable: true
+---
+Hyaline is a tool that serves 2 primary purposes: 1) updating and maintaining documentation so that 2) documentation can be used to help build software products and systems. This body of documentation is intended to help you understand how Hyaline works and how to use Hyaline.
+
+## Structure
+This documentation follows the concepts of [Diátaxis](https://diataxis.fr/) and is structured as follows:
+
+* How To - A series of how to guides showing how to accomplish several common goals
+* Explanation - A series of documents explaining various concepts within Hyaline, including a general overview of how each Hyaline command works
+* Reference - Detailed reference documentation for the various commands, options, and architectural elements of Hyaline
+* Roadmap - A high-level overview of the current and future focus of Hyaline's development
+
+## Next Steps
+To learn how to get started and install Hyaline please visit [Getting Started](./getting-started.md)
+
+For an in depth explanation of Hyaline itself please visit the [Explanation of Hyaline](./explanation/hyaline.md)
+
+For a reference guide to the CLI please visit the [CLI Reference](./reference/cli.md)

--- a/www/content/documentation-v1/reference/cli.md
+++ b/www/content/documentation-v1/reference/cli.md
@@ -1,0 +1,37 @@
+---
+title: "Reference: Hyaline CLI"
+description: Command-line interface reference covering all commands, options, and usage examples
+purpose: Detail each command/sub-command of the Hyaline CLI
+sitemap:
+  disable: true
+---
+## Overview
+This documents the commandline options for the Hyaline Command Line Interface (CLI).
+
+## Commands
+The following commands and sub-commands are available within hyaline.
+
+**Common Options**:
+* `--debug` - (optional) Enables debug output
+
+## help
+`hyaline help` prints out usage information.
+
+**Options**:
+* (none)
+
+**Example**:
+```
+$ hyaline help
+```
+
+## version
+`hyaline version` prints out the currently installed version.
+
+**Options**:
+* (none)
+
+**Example**:
+```
+$ hyaline version
+```

--- a/www/content/documentation-v1/roadmap.md
+++ b/www/content/documentation-v1/roadmap.md
@@ -1,0 +1,17 @@
+---
+title: Roadmap
+description: "Current development focus and upcoming features planned for Hyaline."
+purpose: Explain at a high level what is coming for Hyaline
+lastmod: 2025-06-11
+sitemap:
+  disable: true
+---
+## Main Focus
+* Shipping a general release and gathering feedback
+
+## Up Next
+* React to feedback
+* Recommendation refinements
+* Improve the onboarding experience
+* Support for products/process documentation
+* Implement a centralized server

--- a/www/data/documentation_toc.yml
+++ b/www/data/documentation_toc.yml
@@ -1,0 +1,18 @@
+items:
+  - title: Overview
+    url: /documentation-v1/overview
+  - title: How To
+    items:
+      - title: Install the CLI
+        url: /documentation-v1/how-to/install-cli
+      - title: Run the CLI
+        url: /documentation-v1/how-to/run-cli
+      - title: Build the CLI
+        url: /documentation-v1/how-to/build-cli
+  - title: Explanation
+  - title: Reference
+    items:
+      - title: CLI
+        url: /documentation-v1/reference/cli
+  - title: Roadmap
+    url: /documentation-v1/roadmap

--- a/www/layouts/documentation-v1/list.html
+++ b/www/layouts/documentation-v1/list.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+{{ $overviewPage := .Site.GetPage "/documentation-v1/overview.md" }}
+{{ $tocData := .Site.Data.documentation_toc }}
+{{ partial "table-of-contents.html" (dict "currentPage" $overviewPage "tocData" $tocData) }}
+{{ end }}

--- a/www/layouts/documentation-v1/single.html
+++ b/www/layouts/documentation-v1/single.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+<style>
+  .portrait img {
+    max-width: 360px;
+    margin: 0 auto 1rem auto;
+    display: block;
+  }
+  
+  /* Small viewports and up: float image right */
+  @media (min-width: 640px) {
+    .portrait {
+      display: flow-root;
+    }
+    .portrait img {
+      float: right;
+      margin-left: 1rem;
+    }
+  }
+</style>
+{{ $tocData := .Site.Data.documentation_toc }}
+{{ partial "table-of-contents.html" (dict "currentPage" . "tocData" $tocData) }}
+{{ end }}

--- a/www/layouts/partials/table-of-contents.html
+++ b/www/layouts/partials/table-of-contents.html
@@ -1,0 +1,264 @@
+{{/* 
+  Reusable Table of Contents with Layout
+  Params:
+  - currentPage: The current page context
+  - tocData: The TOC configuration data
+*/}}
+
+{{ $currentPage := .currentPage }}
+{{ $tocData := .tocData }}
+
+<!-- Generate ToC structure -->
+{{ $tocContent := "" }}
+{{ $currentPageTitle := "" }}
+{{ $parentTitle := "" }}
+
+<!-- Use provided TOC data from yml -->
+{{ range $index, $item := $tocData.items }}
+  {{ $tocContent = printf "%s<div class=\"%s\">" $tocContent (cond $item.items "mb-4" "mb-2") }}
+  
+  <!-- Render the item itself -->
+  {{ if $item.url }}
+    <!-- Item has a URL - render as link -->
+    {{ $itemFullURL := printf "%s%s/" $currentPage.Site.BaseURL (strings.TrimPrefix "/" $item.url) }}
+    {{ $isCurrentPage := eq $currentPage.Permalink $itemFullURL }}
+    {{ if $isCurrentPage }}
+      {{ $currentPageTitle = $item.title }}
+    {{ end }}
+    {{ $tocContent = printf "%s<a href=\"%s\" class=\"toc-link block px-3 py-2 font-medium %s rounded-md -ml-3%s\"%s>%s</a>" $tocContent $item.url (cond $isCurrentPage "text-blue-600 bg-blue-50" "text-gray-900 hover:text-blue-600 hover:bg-gray-100") (cond $item.items " mb-2" "") (cond $isCurrentPage " aria-current=\"page\"" "") $item.title }}
+  {{ else }}
+    <!-- Item has no URL - render as header (only if it has children or is standalone) -->
+    {{ $tocContent = printf "%s<h3 class=\"font-medium text-gray-900 mb-2\">%s</h3>" $tocContent $item.title }}
+  {{ end }}
+  
+  <!-- Render children if any -->
+  {{ if $item.items }}
+    {{ $tocContent = printf "%s<ul class=\"space-y-1\">" $tocContent }}
+    {{ range $item.items }}
+      {{ $subItemFullURL := printf "%s%s/" $currentPage.Site.BaseURL (strings.TrimPrefix "/" .url) }}
+      {{ $isCurrentPage := eq $currentPage.Permalink $subItemFullURL }}
+      {{ if $isCurrentPage }}
+        {{ $currentPageTitle = .title }}
+        {{ $parentTitle = $item.title }}
+      {{ end }}
+      {{ $tocContent = printf "%s<li><a href=\"%s\" class=\"toc-link block px-3 py-2 %s rounded-md\"%s>%s</a></li>" $tocContent .url (cond $isCurrentPage "text-blue-600 bg-blue-50 font-medium" "text-gray-700 hover:text-blue-600 hover:bg-gray-100") (cond $isCurrentPage " aria-current=\"page\"" "") .title }}
+    {{ end }}
+    {{ $tocContent = printf "%s</ul>" $tocContent }}
+  {{ end }}
+  
+  {{ $tocContent = printf "%s</div>" $tocContent }}
+{{ end }}
+
+<!-- Complete Layout with ToC -->
+<div class="flex min-h-screen">
+  <!-- Desktop ToC Sidebar (Always visible on desktop) -->
+  <aside 
+    class="hidden lg:flex lg:flex-col min-w-72 bg-gray-50 border-r border-gray-200 overflow-y-auto"
+    aria-label="Table of Contents"
+  >
+    <div class="p-6">
+      <nav>
+        {{ $tocContent | safeHTML }}
+      </nav>
+    </div>
+  </aside>
+
+  <!-- Mobile ToC Sidebar -->
+  <aside 
+    id="mobile-toc-sidebar" 
+    class="lg:hidden fixed left-0 top-0 w-full h-full bg-white shadow-xl z-50 transform -translate-x-full transition-transform duration-300 ease-in-out overflow-y-auto"
+    aria-label="Table of Contents"
+  >
+    <div class="p-6">
+      <div class="flex justify-end items-center">
+        <button
+          id="close-mobile-toc"
+          type="button"
+          class="text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-4 focus:ring-blue-300 focus:ring-offset-2 rounded-md"
+          aria-label="Close table of contents"
+        >
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      
+      <nav>
+        {{ $tocContent | safeHTML }}
+      </nav>
+    </div>
+  </aside>
+
+  <div class="flex-1 min-w-0">
+    <!-- Mobile Top Bar with Breadcrumbs -->
+    <div class="lg:hidden bg-white px-4 sm:px-6 py-2 sticky top-14 shadow-sm">
+      <div class="flex items-center space-x-3">
+        <button
+          id="mobile-toc-button"
+          type="button"
+          class="text-gray-600 hover:text-blue-600 focus:outline-none focus:ring-4 focus:ring-blue-300 focus:ring-offset-2 rounded-md p-1 border border-gray-300 cursor-pointer"
+          aria-label="Open table of contents"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+          </svg>
+        </button>
+        
+        <!-- Breadcrumbs -->
+        <nav class="flex items-center text-sm text-gray-600 min-w-0" aria-label="Breadcrumb">
+          {{ if $currentPageTitle }}
+            {{ if $parentTitle }}
+              <!-- Page with parent category -->
+              <span class="truncate">{{ $parentTitle }}</span>
+              <svg class="h-4 w-4 mx-2 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span class="text-gray-900 font-medium truncate">{{ $currentPageTitle }}</span>
+            {{ else }}
+              <!-- Root level page -->
+              <span class="text-gray-900 font-medium truncate">{{ $currentPageTitle }}</span>
+            {{ end }}
+          {{ else }}
+            <!-- Fallback to page title if not found in tocData -->
+            <span class="text-gray-900 font-medium truncate">{{ .currentPage.Title }}</span>
+          {{ end }}
+        </nav>
+      </div>
+    </div>
+    
+    <div class="px-4 sm:px-6 lg:px-8 py-8">
+      <div class="max-w-5xl mx-auto text-center">
+        <div class="text-left">
+        <!-- Document Header -->
+        <header class="mb-8">
+          <h1 class="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
+            {{ .currentPage.Title }}
+          </h1>
+          {{ if .currentPage.Params.author }}
+            <div class="text-gray-600 mb-6">
+              <span class="font-medium">{{ .currentPage.Params.author }}</span>
+              {{ if .currentPage.Lastmod }}
+                - <time datetime="{{ .currentPage.Lastmod.Format "2006-01-02" }}">Last modified {{ .currentPage.Lastmod.Format "January 2, 2006" }}</time>
+              {{ end }}
+            </div>
+          {{ else if .currentPage.Lastmod }}
+            <div class="text-gray-600 mb-6">
+              <time datetime="{{ .currentPage.Lastmod.Format "2006-01-02" }}">Last modified {{ .currentPage.Lastmod.Format "January 2, 2006" }}</time>
+            </div>
+          {{ end }}
+        </header>
+
+        <!-- Document Content -->
+        <div class="space-y-8 prose max-w-none prose-a:text-blue-600 prose-code:before:hidden prose-code:after:hidden break-words">
+          {{ .currentPage.Content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  // Mobile ToC Toggle
+  const mobileTocButton = document.getElementById("mobile-toc-button");
+  const mobileTocSidebar = document.getElementById("mobile-toc-sidebar");
+  const closeMobileToc = document.getElementById("close-mobile-toc");
+  
+  function setLinksTabIndex(value) {
+    if (mobileTocSidebar) {
+      const links = mobileTocSidebar.querySelectorAll('a');
+      if (value === null) {
+        links.forEach(el => el.removeAttribute('tabindex'));
+      } else {
+        links.forEach(el => el.setAttribute('tabindex', value));
+      }
+    }
+  }
+
+  // Initialize mobile TOC as unfocusable since it starts collapsed
+  setLinksTabIndex('-1');
+  function openMobileToc() {
+    if (mobileTocSidebar) {
+      mobileTocSidebar.classList.remove("-translate-x-full");
+      mobileTocSidebar.setAttribute("aria-hidden", "false");
+      
+      // Make all links in the sidebar focusable
+      setLinksTabIndex(null);
+      
+      // Focus management for accessibility
+      if (closeMobileToc) {
+        closeMobileToc.focus();
+      }
+      
+      // Trap focus within the sidebar
+      document.addEventListener("keydown", trapFocus);
+      
+      // Disable body scroll
+      document.body.style.overflow = "hidden";
+    }
+  }
+
+  function closeMobileTocFn() {
+    if (mobileTocSidebar && mobileTocButton) {
+      mobileTocSidebar.classList.add("-translate-x-full");
+      mobileTocSidebar.setAttribute("aria-hidden", "true");
+      
+      // Make all links in the sidebar unfocusable
+      setLinksTabIndex('-1');
+      
+      // Return focus to the button that opened the sidebar
+      mobileTocButton.focus();
+      
+      // Remove focus trap
+      document.removeEventListener("keydown", trapFocus);
+      
+      // Re-enable body scroll
+      document.body.style.overflow = "";
+    }
+  }
+
+  function trapFocus(e) {
+    if (e.key === "Escape") {
+      closeMobileTocFn();
+      return;
+    }
+
+    if (e.key === "Tab" && mobileTocSidebar) {
+      const focusableElements = mobileTocSidebar.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          lastElement.focus();
+          e.preventDefault();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          firstElement.focus();
+          e.preventDefault();
+        }
+      }
+    }
+  }
+
+  // Event listeners for mobile ToC
+  if (mobileTocButton) {
+    mobileTocButton.addEventListener("click", openMobileToc);
+  }
+
+  if (closeMobileToc) {
+    closeMobileToc.addEventListener("click", closeMobileTocFn);
+  }
+
+  // Handle window resize
+  window.addEventListener("resize", function () {
+    // Close mobile ToC on desktop
+    if (window.innerWidth >= 1024) {
+      closeMobileTocFn();
+    }
+  });
+});
+</script>


### PR DESCRIPTION
# Purpose
The purpose of this change is to set up a new set of "v1" documentation

- Ticket: https://github.com/appgardenstudios/hyaline/issues/205

# Changes
- Created a documentation-v1/ set of documentation
- Copied over docs that don't need to be changed, ensuring each one would be hidden from the sitemap
- Implemented a new way of doing the ToC that was based on the config file

# Testing
Run `make` in `www` and navigate to http://localhost:1313/documentation-v1 to verify changes