### PR TITLE
Correct the sections portion of the check diff prompts

### DIFF
--- a/cli/internal/check/diff.go
+++ b/cli/internal/check/diff.go
@@ -312,10 +312,15 @@ func formatCheckPromptSections(sections []docs.FilteredSection, indent int) stri
 			str.WriteString(fmt.Sprintf("%s<section_purpose>%s</section_purpose>\n", strings.Repeat(" ", indent), section.Section.Purpose))
 		}
 
+		// <sections> if present
+		if len(section.Sections) > 0 {
+			str.WriteString(formatCheckPromptSections(section.Sections, indent))
+		}
+
 		indent -= 2
 
 		// </section>
-		str.WriteString(fmt.Sprintf("%s<section>\n", strings.Repeat(" ", indent)))
+		str.WriteString(fmt.Sprintf("%s</section>\n", strings.Repeat(" ", indent)))
 	}
 
 	indent -= 2


### PR DESCRIPTION
# Purpose
The purpose of this change is to correct the `<section>` part of `check-diff`

# Changes
- Recursively render sections
- Correctly terminate with `</section>`

# Testing
Run the "Check Diff (branch)" launch target and verify that the prompt sent is formatted correctly