### PR TITLE
Extract Purpose - handle code blocks

### DIFF
--- a/cli/internal/extract/extractSections.go
+++ b/cli/internal/extract/extractSections.go
@@ -50,10 +50,17 @@ func getMarkdownSections(lines []string) *section {
 	originalFullNames := make(map[string]struct{})
 	generatedFullNames := make(map[string]struct{})
 
+	inCodeBlock := false
+
 	for _, line := range lines {
+		// If the line starts with ```, enter or exit the code block
+		if strings.HasPrefix(line, "```") {
+			inCodeBlock = !inCodeBlock
+		}
+
 		// If line starts with #, modify current to the correct level
 		level := countPounds(line)
-		if level == 0 {
+		if level == 0 || inCodeBlock {
 			// Add to current section
 			current.Content = current.Content + "\n" + line
 		} else {

--- a/cli/internal/extract/extractSections_test.go
+++ b/cli/internal/extract/extractSections_test.go
@@ -28,6 +28,29 @@ func TestGetMarkdownSections_BasicFunctionality(t *testing.T) {
 	}
 }
 
+func TestGetMarkdownSections_CodeBlocks(t *testing.T) {
+	lines := []string{
+		"Start",
+		"```",
+		"# Section 1",
+		"Content",
+		"```",
+		"In Between",
+		"```",
+		"# Section 2",
+		"Content",
+		"```",
+		"End",
+	}
+
+	root := getMarkdownSections(lines)
+
+	if len(root.Children) != 0 {
+		t.Error("Children should be empty")
+	}
+
+}
+
 func TestGetMarkdownSections_DuplicateNames(t *testing.T) {
 	lines := []string{
 		"# Section A (1)",


### PR DESCRIPTION
# Purpose
The purpose of this change is to ignore code blocks when parsing sections as discovered while implementing https://github.com/appgardenstudios/hyaline/issues/301.

# Changes
- Detect if we are in a code block when parsing sections. If we are, just add the line and don't treat it as a section change.

# Testing
There is a unit test for this now, so just run the unit tests a la `make test` in the `cli/` directory.