### PR TITLE
Only include LLM recommendations for real documents and sections

### DIFF
--- a/cli/internal/action/checkDiff.go
+++ b/cli/internal/action/checkDiff.go
@@ -8,6 +8,7 @@ import (
 	"hyaline/internal/config"
 	"hyaline/internal/docs"
 	"hyaline/internal/github"
+	"hyaline/internal/llm"
 	"hyaline/internal/repo"
 	"hyaline/internal/sqlite"
 	"log/slog"
@@ -246,7 +247,7 @@ func CheckDiff(args *CheckDiffArgs) error {
 
 func getRecommendations(filteredFiles []code.FilteredFile, documents []*docs.FilteredDoc, pr *github.PullRequest, issues []*github.Issue, changedFiles map[string]struct{}, checkConfig *config.Check, llmConfig *config.LLM) ([]CheckRecommendation, check.FileCheckContextHashes, error) {
 	// Check Diff
-	results, fileCheckContextHashes, err := check.Diff(filteredFiles, documents, pr, issues, checkConfig, llmConfig)
+	results, fileCheckContextHashes, err := check.Diff(filteredFiles, documents, pr, issues, checkConfig, llmConfig, llm.CallLLM)
 	if err != nil {
 		slog.Debug("getRecommendations could not check diff", "error", err)
 		return nil, nil, err

--- a/cli/internal/check/diff.go
+++ b/cli/internal/check/diff.go
@@ -523,21 +523,11 @@ func checkNewUpdateIfSections(glob string, sections []docs.FilteredSection, filt
 	}
 }
 
-func addSectionsToValidIDMap(validIDs map[string]bool, sections []docs.FilteredSection) {
-	for _, section := range sections {
-		compositeID := fmt.Sprintf("%s/%s#%s", section.Section.SourceID, section.Section.DocumentID, section.Section.ID)
-		validIDs[compositeID] = true
-		if len(section.Sections) > 0 {
-			addSectionsToValidIDMap(validIDs, section.Sections)
-		}
-	}
-}
-
 func buildValidIDMap(documents []*docs.FilteredDoc) map[string]bool {
 	validIDs := make(map[string]bool)
 
-	var recursiveAddSections func(sections []docs.FilteredSection)
-	recursiveAddSections = func(sections []docs.FilteredSection) {
+	var addSectionsToValidIDMap func(sections []docs.FilteredSection)
+	addSectionsToValidIDMap = func(sections []docs.FilteredSection) {
 		for _, section := range sections {
 			uri := docs.DocumentURI{
 				SourceID:     section.Section.SourceID,
@@ -546,7 +536,7 @@ func buildValidIDMap(documents []*docs.FilteredDoc) map[string]bool {
 			}
 			validIDs[uri.String()] = true
 			if len(section.Sections) > 0 {
-				recursiveAddSections(section.Sections)
+				addSectionsToValidIDMap(section.Sections)
 			}
 		}
 	}
@@ -557,7 +547,7 @@ func buildValidIDMap(documents []*docs.FilteredDoc) map[string]bool {
 			DocumentPath: document.Document.ID,
 		}
 		validIDs[uri.String()] = true
-		recursiveAddSections(document.Sections)
+		addSectionsToValidIDMap(document.Sections)
 	}
 
 	return validIDs

--- a/cli/internal/check/diff_test.go
+++ b/cli/internal/check/diff_test.go
@@ -1,0 +1,99 @@
+package check
+
+import (
+	"encoding/json"
+	"hyaline/internal/code"
+	"hyaline/internal/config"
+	"hyaline/internal/docs"
+	"hyaline/internal/llm"
+	"hyaline/internal/sqlite"
+	"testing"
+)
+
+func TestDiff_IgnoresInvalidIDsFromLLM(t *testing.T) {
+	// 1. Mock llm.CallLLM
+	originalCallLLM := callLLM
+	defer func() { callLLM = originalCallLLM }()
+
+	callLLM = func(systemPrompt string, prompt string, tools []*llm.Tool, cfg *config.LLM) (string, error) {
+		// Simulate LLM calling the 'needs_update' tool with valid and invalid IDs
+		for _, tool := range tools {
+			if tool.Name == checkNeedsUpdateName {
+				updates := checkNeedsUpdateSchema{
+					Entries: []checkNeedsUpdateSchemaEntry{
+						{ID: "document://docs/valid.md", Reason: "This is a valid doc"},
+						{ID: "document://invalid/doc.md", Reason: "This is an invalid doc"},
+						{ID: "document://docs/valid.md#valid-section", Reason: "This is a valid section"},
+						{ID: "document://docs/valid.md#valid-section/nested-section", Reason: "This is a nested section"},
+						{ID: "document://docs/valid.md#invalid-section", Reason: "This is an invalid section"},
+					},
+				}
+				inputBytes, _ := json.Marshal(updates)
+				tool.Callback(string(inputBytes))
+				break
+			}
+		}
+		return "", nil
+	}
+
+	// 2. Define valid documents and sections
+	documents := []*docs.FilteredDoc{
+		{
+			Document: &sqlite.DOCUMENT{ID: "valid.md", SourceID: "docs"},
+			Sections: []docs.FilteredSection{
+				{
+					Section: &sqlite.SECTION{ID: "valid-section", DocumentID: "valid.md", SourceID: "docs"},
+					Sections: []docs.FilteredSection{
+						{
+							Section: &sqlite.SECTION{ID: "valid-section/nested-section", DocumentID: "valid.md", SourceID: "docs"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// 3. Define other inputs for Diff
+	files := []code.FilteredFile{
+		{Filename: "some/file.go", Action: code.ActionModify, Contents: []byte("hello")},
+	}
+	checkCfg := &config.Check{Options: config.CheckOptions{UpdateIf: config.CheckOptionsUpdateIf{}}}
+	llmCfg := &config.LLM{}
+
+	// 4. Call Diff
+	results, _, err := Diff(files, documents, nil, nil, checkCfg, llmCfg)
+	if err != nil {
+		t.Fatalf("Diff returned an error: %v", err)
+	}
+
+	// 5. Assert results
+	if len(results) != 3 {
+		t.Errorf("Expected 3 results (doc, section, nested section), but got %d", len(results))
+	}
+
+	foundValidDoc := false
+	foundValidSection := false
+	foundNestedSection := false
+	for _, result := range results {
+		// The result struct splits the ID, so we check the components
+		if result.Source == "docs" && result.Document == "valid.md" && len(result.Section) == 0 {
+			foundValidDoc = true
+		}
+		if result.Source == "docs" && result.Document == "valid.md" && len(result.Section) == 1 && result.Section[0] == "valid-section" {
+			foundValidSection = true
+		}
+		if result.Source == "docs" && result.Document == "valid.md" && len(result.Section) == 2 && result.Section[0] == "valid-section" && result.Section[1] == "nested-section" {
+			foundNestedSection = true
+		}
+	}
+
+	if !foundValidDoc {
+		t.Errorf("Did not find expected result for docs/valid.md")
+	}
+	if !foundValidSection {
+		t.Errorf("Did not find expected result for docs/valid.md#valid-section")
+	}
+	if !foundNestedSection {
+		t.Errorf("Did not find expected result for docs/valid.md#valid-section/nested-section")
+	}
+}

--- a/cli/internal/check/diff_test.go
+++ b/cli/internal/check/diff_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestDiff_IgnoresInvalidIDsFromLLM(t *testing.T) {
 	// 1. Mock llm.CallLLM
-	originalCallLLM := callLLM
-	defer func() { callLLM = originalCallLLM }()
-
+	var callLLM llm.CallLLMHandler
 	callLLM = func(systemPrompt string, prompt string, tools []*llm.Tool, cfg *config.LLM) (string, error) {
 		// Simulate LLM calling the 'needs_update' tool with valid and invalid IDs
 		for _, tool := range tools {
@@ -61,7 +59,7 @@ func TestDiff_IgnoresInvalidIDsFromLLM(t *testing.T) {
 	llmCfg := &config.LLM{}
 
 	// 4. Call Diff
-	results, _, err := Diff(files, documents, nil, nil, checkCfg, llmCfg)
+	results, _, err := Diff(files, documents, nil, nil, checkCfg, llmCfg, callLLM)
 	if err != nil {
 		t.Fatalf("Diff returned an error: %v", err)
 	}

--- a/cli/internal/llm/call.go
+++ b/cli/internal/llm/call.go
@@ -17,6 +17,8 @@ type Tool struct {
 	Callback func(string) (bool, string, error)
 }
 
+type CallLLMHandler func(systemPrompt string, userPrompt string, tools []*Tool, cfg *config.LLM) (string, error)
+
 func CallLLM(systemPrompt string, userPrompt string, tools []*Tool, cfg *config.LLM) (result string, err error) {
 	if cfg == nil || cfg.Provider == "" {
 		slog.Error("llm configuration must be present to call an llm")


### PR DESCRIPTION
# Purpose
The purpose of this change is to filter out recommendations that don't match valid documents/sections

# Changes
- Filter out invalid recommendations
- Updated existing code to use the `DocumentURI` utility for consistency in how parsing and stringifying happens
- Add test

# Testing
- Run `make test`
- Because of the non-deterministic nature of LLMs and how good they've gotten, it's difficult to reliably test the case where results are filtered out, but it would be good to run the "Check PR" launch config to ensure there are no regressions