### PR TITLE
MCP Server Improvements - support documentation from config repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -225,6 +225,19 @@
         "--documentation", "../.vscode/hyaline/serve-mcp/documentation.sqlite"
       ]
     },{
+      "name": "Serve MCP (GitHub)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "cwd": "${workspaceFolder}/cli/",
+      "program": "${workspaceFolder}/cli/cmd/hyaline.go",
+      "envFile": "${workspaceFolder}/cli/.env",
+      "args":[
+        "--debug",
+        "serve", "mcp",
+        "--github-repo", "appgardenstudios/hyaline-example"
+      ]
+    },{
       "name": "Export Documentation (fs)",
       "type": "go",
       "request": "launch",

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -3,6 +3,10 @@ FROM golang:1.24 AS builder
 
 ARG VERSION=development
 
+# This will be copied over as a /tmp dir for Hyaline to use
+# for temporary files (e.g. SQLite DB downloads)
+RUN mkdir -p /tmp-hyaline
+
 WORKDIR /app
 
 # Copy the code
@@ -21,6 +25,7 @@ LABEL org.opencontainers.image.source=https://github.com/appgardenstudios/hyalin
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /hyaline /hyaline
+COPY --from=builder /tmp-hyaline /tmp
 
 ENTRYPOINT ["/hyaline"]
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -24,8 +24,8 @@ FROM scratch
 LABEL org.opencontainers.image.source=https://github.com/appgardenstudios/hyaline
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /hyaline /hyaline
 COPY --from=builder /tmp-hyaline /tmp
+COPY --from=builder /hyaline /hyaline
 
 ENTRYPOINT ["/hyaline"]
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -19,6 +19,7 @@ FROM scratch
 
 LABEL org.opencontainers.image.source=https://github.com/appgardenstudios/hyaline
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /hyaline /hyaline
 
 ENTRYPOINT ["/hyaline"]

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,6 +36,7 @@ There is a `.vscode/launch.json` file checked in that has various debugger launc
 HYALINE_ANTHROPIC_KEY= #The Anthropic API key
 HYALINE_OPENAI_KEY= #The OpenAI API key
 HYALINE_GITHUB_PAT= #A GitHub Personal Access Token that has read access to github.com/appgardenstudios/hyaline-example
+HYALINE_CONFIG_GITHUB_TOKEN= #A GitHub Personal Access Token that has Action read/write access to github.com/appgardenstudios/hyaline-example
 HYALINE_SSH_PEM= #A SSH key that has pull access to github.com/appgardenstudios/hyaline-example. Note that this will need to be ""'d and newlines replaced with \n
 HYALINE_SSH_PASSWORD= #A password for the PEM above (blank if PEM is not password protected)
 ```
@@ -48,7 +49,8 @@ Unit tests are run with `make test`, and there are e2e tests that invoke the act
 
 Note that the following env vars must be set for the `e2e` tests to work and pass:
 * **HYALINE_SSH_PEM** (with access to `github.com/appgardenstudios/hyaline-example`)
-* **HYALINE_GITHUB_PAT** (with access to `github.com/appgardenstudios/hyaline-example`)
+* **HYALINE_GITHUB_PAT** (with access to `github.com/appgardenstudios/hyaline-example`):
+* **HYALINE_CONFIG_GITHUB_TOKEN** (with action read/write access to `github.com/appgardenstudios/hyaline-example`)
 
 Note that the e2e test [updatePR_test.go](./e2e/updatePR_test.go) creates a comment on a PR and cleans it up using the GitHub CLI (`gh`).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,7 +36,7 @@ There is a `.vscode/launch.json` file checked in that has various debugger launc
 HYALINE_ANTHROPIC_KEY= #The Anthropic API key
 HYALINE_OPENAI_KEY= #The OpenAI API key
 HYALINE_GITHUB_PAT= #A GitHub Personal Access Token that has read access to github.com/appgardenstudios/hyaline-example
-HYALINE_CONFIG_GITHUB_TOKEN= #A GitHub Personal Access Token that has Action read/write access to github.com/appgardenstudios/hyaline-example
+_HYALINE_TEST_GITHUB_TOKEN= #A GitHub Personal Access Token that has Action read/write access to github.com/appgardenstudios/hyaline-example
 HYALINE_SSH_PEM= #A SSH key that has pull access to github.com/appgardenstudios/hyaline-example. Note that this will need to be ""'d and newlines replaced with \n
 HYALINE_SSH_PASSWORD= #A password for the PEM above (blank if PEM is not password protected)
 ```
@@ -50,7 +50,7 @@ Unit tests are run with `make test`, and there are e2e tests that invoke the act
 Note that the following env vars must be set for the `e2e` tests to work and pass:
 * **HYALINE_SSH_PEM** (with access to `github.com/appgardenstudios/hyaline-example`)
 * **HYALINE_GITHUB_PAT** (with access to `github.com/appgardenstudios/hyaline-example`):
-* **HYALINE_CONFIG_GITHUB_TOKEN** (with action read/write access to `github.com/appgardenstudios/hyaline-example`)
+* **_HYALINE_TEST_GITHUB_TOKEN** (with action read/write access to `github.com/appgardenstudios/hyaline-example`)
 
 Note that the e2e test [updatePR_test.go](./e2e/updatePR_test.go) creates a comment on a PR and cleans it up using the GitHub CLI (`gh`).
 

--- a/cli/cmd/hyaline/serve.go
+++ b/cli/cmd/hyaline/serve.go
@@ -37,10 +37,11 @@ func Serve(logLevel *slog.LevelVar, version string) *cli.Command {
 						Usage: "The path to the SQLite database within the GitHub artifact",
 					},
 					&cli.StringFlag{
-						Name:     "github-token",
-						EnvVars:  []string{"HYALINE_CONFIG_GITHUB_TOKEN"},
+						Name: "github-token",
+						// Only intended for internal testing purposes
+						EnvVars:  []string{"_HYALINE_TEST_GITHUB_TOKEN"},
 						Required: false,
-						Usage:    "A GitHub Personal Access Token to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`.",
+						Usage:    "A GitHub Personal Access Token to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`. Consider setting this using an environment variable (e.g. `--github-token $HYALINE_SERVE_MCP_GITHUB_TOKEN`).",
 					},
 				},
 				Action: func(cCtx *cli.Context) error {

--- a/cli/cmd/hyaline/serve.go
+++ b/cli/cmd/hyaline/serve.go
@@ -40,7 +40,7 @@ func Serve(logLevel *slog.LevelVar, version string) *cli.Command {
 						Name:     "github-token",
 						EnvVars:  []string{"HYALINE_CONFIG_GITHUB_TOKEN"},
 						Required: false,
-						Usage:    "A GitHub Personal Access Tokenccess to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`.",
+						Usage:    "A GitHub Personal Access Token to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`.",
 					},
 				},
 				Action: func(cCtx *cli.Context) error {

--- a/cli/e2e/_golden/serve-mcp-reload-documentation-list-after.txt
+++ b/cli/e2e/_golden/serve-mcp-reload-documentation-list-after.txt
@@ -1,0 +1,84 @@
+The <documents> XML structure contains all available documents and sections with their corresponding document URIs, along with <purpose> and <tags> metadata when available.
+
+<documents>
+          <document>
+            <uri>document://mcp-test/docs/doc.html</uri>
+            <source>docs/doc.html</source>
+            <purpose>Detailed documentation page</purpose>
+            <tags>
+              <tag>
+                <key>audience</key>
+                <value>admin</value>
+                <value>developer</value>
+              </tag>
+              <tag>
+                <key>category</key>
+                <value>tutorial</value>
+              </tag>
+              <tag>
+                <key>importance</key>
+                <value>medium</value>
+              </tag>
+              <tag>
+                <key>system</key>
+                <value>mcp-test</value>
+              </tag>
+              <tag>
+                <key>type</key>
+                <value>guide</value>
+              </tag>
+            </tags>
+            <sections>
+              <section>
+                <name>First Section</name>
+                <purpose>Introduction section explaining the core concepts</purpose>
+                <tags>
+                  <tag>
+                    <key>importance</key>
+                    <value>high</value>
+                  </tag>
+                  <tag>
+                    <key>section_type</key>
+                    <value>intro</value>
+                  </tag>
+                </tags>
+              </section>
+              <section>
+                <name>Sub Section 1</name>
+              </section>
+              <section>
+                <name>Sub Section 2</name>
+              </section>
+            </sections>
+          </document>
+          <document>
+            <uri>document://mcp-test/docs/index.html</uri>
+            <source>docs/index.html</source>
+            <purpose>Main documentation index page</purpose>
+            <tags>
+              <tag>
+                <key>audience</key>
+                <value>developer</value>
+              </tag>
+              <tag>
+                <key>category</key>
+                <value>overview</value>
+                <value>reference</value>
+              </tag>
+              <tag>
+                <key>importance</key>
+                <value>high</value>
+              </tag>
+              <tag>
+                <key>system</key>
+                <value>mcp-test</value>
+              </tag>
+              <tag>
+                <key>type</key>
+                <value>guide</value>
+              </tag>
+            </tags>
+            <sections>
+            </sections>
+          </document>
+</documents>

--- a/cli/e2e/_golden/serve-mcp-reload-documentation-list-before.txt
+++ b/cli/e2e/_golden/serve-mcp-reload-documentation-list-before.txt
@@ -1,0 +1,70 @@
+The <documents> XML structure contains all available documents and sections with their corresponding document URIs, along with <purpose> and <tags> metadata when available.
+
+<documents>
+          <document>
+            <uri>document://backend/CHANGELOG.md</uri>
+            <source>e2e/_input/audit-documentation/docs/CHANGELOG.md</source>
+            <purpose>This document tracks all changes and releases.</purpose>
+            <tags>
+              <tag>
+                <key>type</key>
+                <value>reference</value>
+              </tag>
+            </tags>
+            <sections>
+              <section>
+                <name>Changelog</name>
+              </section>
+              <section>
+                <name>[1.0.0] - 2024-01-15</name>
+              </section>
+              <section>
+                <name>Added</name>
+              </section>
+              <section>
+                <name>Changed</name>
+              </section>
+              <section>
+                <name>Fixed</name>
+              </section>
+            </sections>
+          </document>
+          <document>
+            <uri>document://backend/NOPURPOSE.md</uri>
+            <source>e2e/_input/audit-documentation/docs/NOPURPOSE.md</source>
+            <sections>
+              <section>
+                <name>Document Without Purpose</name>
+              </section>
+            </sections>
+          </document>
+          <document>
+            <uri>document://backend/README.md</uri>
+            <source>e2e/_input/audit-documentation/docs/README.md</source>
+            <purpose>This document provides an overview of the project and installation instructions.</purpose>
+            <tags>
+              <tag>
+                <key>level</key>
+                <value>beginner</value>
+              </tag>
+              <tag>
+                <key>type</key>
+                <value>guide</value>
+              </tag>
+            </tags>
+            <sections>
+              <section>
+                <name>Test Project</name>
+              </section>
+              <section>
+                <name>Installation</name>
+              </section>
+              <section>
+                <name>Usage</name>
+              </section>
+              <section>
+                <name>Features</name>
+              </section>
+            </sections>
+          </document>
+</documents>

--- a/cli/e2e/github.go
+++ b/cli/e2e/github.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+)
+
+// dispatchWorkflow triggers a GitHub Actions workflow and waits for it to complete
+func dispatchWorkflow(t *testing.T, token string, repo string, workflowFileName string, inputs map[string]interface{}) {
+	t.Helper()
+
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		t.Fatalf("invalid repo format: %s", repo)
+	}
+	owner, repoName := parts[0], parts[1]
+
+	client := github.NewClient(nil).WithAuthToken(token)
+	ctx := context.Background()
+
+	// Get the current latest run ID before dispatching
+	runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repoName, workflowFileName, &github.ListWorkflowRunsOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to list workflow runs: %v", err)
+	}
+
+	var lastRunID int64
+	if runs.GetTotalCount() > 0 && len(runs.WorkflowRuns) > 0 {
+		lastRunID = runs.WorkflowRuns[0].GetID()
+	}
+
+	// Get the default branch
+	repoInfo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		t.Fatalf("failed to get repository info: %v", err)
+	}
+	defaultBranch := repoInfo.GetDefaultBranch()
+
+	// Dispatch the workflow
+	t.Logf("Dispatching workflow %s with inputs: %v on branch %s", workflowFileName, inputs, defaultBranch)
+	_, err = client.Actions.CreateWorkflowDispatchEventByFileName(ctx, owner, repoName, workflowFileName, github.CreateWorkflowDispatchEventRequest{
+		Ref:    defaultBranch,
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("failed to dispatch workflow: %v", err)
+	}
+
+	// Wait for the new run to appear and complete
+	t.Logf("Waiting for workflow run to complete...")
+	timeout := time.After(60 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("timeout waiting for workflow to complete")
+		case <-ticker.C:
+			runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repoName, workflowFileName, &github.ListWorkflowRunsOptions{
+				ListOptions: github.ListOptions{
+					PerPage: 5,
+				},
+			})
+			if err != nil {
+				t.Fatalf("failed to list workflow runs: %v", err)
+			}
+
+			// Find the newest run that's newer than lastRunID
+			for _, run := range runs.WorkflowRuns {
+				if run.GetID() > lastRunID {
+					status := run.GetStatus()
+					conclusion := run.GetConclusion()
+					t.Logf("Workflow run %d status: %s, conclusion: %s", run.GetID(), status, conclusion)
+
+					if status == "completed" {
+						if conclusion == "success" {
+							t.Logf("Workflow completed successfully")
+							return
+						}
+						t.Fatalf("workflow failed with conclusion: %s", conclusion)
+					}
+					// Still running, continue waiting
+					break
+				}
+			}
+		}
+	}
+}

--- a/cli/e2e/github.go
+++ b/cli/e2e/github.go
@@ -67,15 +67,16 @@ func dispatchWorkflow(t *testing.T, token string, repo string, workflowFileName 
 		case <-ticker.C:
 			runs, _, err := client.Actions.ListWorkflowRunsByFileName(ctx, owner, repoName, workflowFileName, &github.ListWorkflowRunsOptions{
 				ListOptions: github.ListOptions{
-					PerPage: 5,
+					PerPage: 1,
 				},
 			})
 			if err != nil {
 				t.Fatalf("failed to list workflow runs: %v", err)
 			}
 
-			// Find the newest run that's newer than lastRunID
-			for _, run := range runs.WorkflowRuns {
+			// Check the newest run (at index 0) if it's newer than lastRunID
+			if len(runs.WorkflowRuns) > 0 {
+				run := runs.WorkflowRuns[0]
 				if run.GetID() > lastRunID {
 					status := run.GetStatus()
 					conclusion := run.GetConclusion()
@@ -89,7 +90,6 @@ func dispatchWorkflow(t *testing.T, token string, repo string, workflowFileName 
 						t.Fatalf("workflow failed with conclusion: %s", conclusion)
 					}
 					// Still running, continue waiting
-					break
 				}
 			}
 		}

--- a/cli/e2e/serveMCP.go
+++ b/cli/e2e/serveMCP.go
@@ -13,7 +13,6 @@ import (
 )
 
 // setupServeMCPClient creates and initializes an MCP client for testing the serve mcp command
-// The command string should contain the full command arguments (e.g., "serve mcp --documentation ./test.db")
 func setupServeMCPClient(t *testing.T, command string) *mcpClient.Client {
 	// Build the hyaline binary path relative to this test file
 	dir, err := os.Getwd()
@@ -60,11 +59,7 @@ func setupServeMCPClient(t *testing.T, command string) *mcpClient.Client {
 
 // callServeMCPServer creates an MCP client, performs a request, and writes output to the provided path
 func callServeMCPServer(t *testing.T, dbPath string, request mcp.CallToolRequest, outputPath string) {
-	absDBPath, err := filepath.Abs(dbPath)
-	if err != nil {
-		t.Fatalf("expected to get absolute path for database: %v", err)
-	}
-	client := setupServeMCPClient(t, "serve mcp --documentation "+absDBPath)
+	client := setupServeMCPClient(t, "serve mcp --documentation "+dbPath)
 	ctx := context.Background()
 
 	response, err := client.CallTool(ctx, request)

--- a/cli/e2e/serveMCPToolsGetDocuments_test.go
+++ b/cli/e2e/serveMCPToolsGetDocuments_test.go
@@ -108,7 +108,7 @@ func TestServeMCPGetDocumentsNotFound(t *testing.T) {
 }
 
 func TestServeMCPGetDocumentsInvalidURI(t *testing.T) {
-	client := setupServeMCPClient(t, ServeMCPClientOptions{DBPath: "./_input/serve-mcp/documentation.sqlite"})
+	client := setupServeMCPClient(t, "serve mcp --documentation ./_input/serve-mcp/documentation.sqlite")
 	ctx := context.Background()
 
 	// Test with invalid URI format

--- a/cli/e2e/serveMCPToolsGetDocuments_test.go
+++ b/cli/e2e/serveMCPToolsGetDocuments_test.go
@@ -108,7 +108,7 @@ func TestServeMCPGetDocumentsNotFound(t *testing.T) {
 }
 
 func TestServeMCPGetDocumentsInvalidURI(t *testing.T) {
-	client := setupServeMCPClient(t, "./_input/serve-mcp/documentation.sqlite")
+	client := setupServeMCPClient(t, ServeMCPClientOptions{DBPath: "./_input/serve-mcp/documentation.sqlite"})
 	ctx := context.Background()
 
 	// Test with invalid URI format

--- a/cli/e2e/serveMCPToolsListDocuments_test.go
+++ b/cli/e2e/serveMCPToolsListDocuments_test.go
@@ -108,7 +108,7 @@ func TestServeMCPListDocumentsNotFound(t *testing.T) {
 }
 
 func TestServeMCPListDocumentsInvalidURI(t *testing.T) {
-	client := setupServeMCPClient(t, "./_input/serve-mcp/documentation.sqlite")
+	client := setupServeMCPClient(t, ServeMCPClientOptions{DBPath: "./_input/serve-mcp/documentation.sqlite"})
 	ctx := context.Background()
 
 	// Test with invalid URI format

--- a/cli/e2e/serveMCPToolsListDocuments_test.go
+++ b/cli/e2e/serveMCPToolsListDocuments_test.go
@@ -108,7 +108,7 @@ func TestServeMCPListDocumentsNotFound(t *testing.T) {
 }
 
 func TestServeMCPListDocumentsInvalidURI(t *testing.T) {
-	client := setupServeMCPClient(t, ServeMCPClientOptions{DBPath: "./_input/serve-mcp/documentation.sqlite"})
+	client := setupServeMCPClient(t, "serve mcp --documentation ./_input/serve-mcp/documentation.sqlite")
 	ctx := context.Background()
 
 	// Test with invalid URI format

--- a/cli/e2e/serveMCPToolsReloadDocumentation_test.go
+++ b/cli/e2e/serveMCPToolsReloadDocumentation_test.go
@@ -1,0 +1,98 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestServeMCPReloadDocumentation(t *testing.T) {
+	githubToken := os.Getenv("HYALINE_CONFIG_GITHUB_TOKEN")
+	githubRepo := "appgardenstudios/hyaline-example"
+
+	// Set initial documentation to documentation_1.db
+	dispatchWorkflow(t, githubToken, githubRepo, "set-current-documentation.yml", map[string]interface{}{
+		"artifact_source": "documentation_1.db",
+	})
+
+	client := setupServeMCPClient(t, ServeMCPClientOptions{
+		GitHubRepo:     githubRepo,
+		GitHubArtifact: "_current-documentation",
+		GitHubToken:    githubToken,
+	})
+	ctx := context.Background()
+
+	// 1. List documents before reload
+	listRequest := mcp.CallToolRequest{}
+	listRequest.Params.Name = "list_documents"
+	listResponse, err := client.CallTool(ctx, listRequest)
+	if err != nil {
+		t.Fatalf("expected to call 'list_documents' tool successfully: %v", err)
+	}
+	listContent, ok := listResponse.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatal("expected content to be of type TextContent")
+	}
+
+	// Write output for golden file comparison - before reload (documentation_1.db)
+	goldenPathBefore := "./_golden/serve-mcp-reload-documentation-list-before.txt"
+	outputPathBefore := fmt.Sprintf("./_output/serve-mcp-reload-documentation-list-before-%d.txt", time.Now().UnixMilli())
+	err = os.WriteFile(outputPathBefore, []byte(listContent.Text), 0644)
+	if err != nil {
+		t.Fatalf("expected to write output file: %v", err)
+	}
+
+	if *update {
+		updateGolden(goldenPathBefore, outputPathBefore, t)
+	}
+
+	compareFiles(goldenPathBefore, outputPathBefore, t)
+
+	// 2. Switch to documentation_2.db and reload
+	dispatchWorkflow(t, githubToken, githubRepo, "set-current-documentation.yml", map[string]interface{}{
+		"artifact_source": "documentation_2.db",
+	})
+
+	// 3. Reload documentation
+	reloadRequest := mcp.CallToolRequest{}
+	reloadRequest.Params.Name = "reload_documentation"
+	reloadResponse, err := client.CallTool(ctx, reloadRequest)
+	if err != nil {
+		t.Fatalf("expected to call 'reload_documentation' tool successfully: %v", err)
+	}
+	reloadContent, ok := reloadResponse.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatal("expected content to be of type TextContent")
+	}
+	if reloadContent.Text != "Documentation reloaded successfully." {
+		t.Fatalf("unexpected reload response: %s", reloadContent.Text)
+	}
+
+	// 4. List documents after reload
+	listResponseAfter, err := client.CallTool(ctx, listRequest)
+	if err != nil {
+		t.Fatalf("expected to call 'list_documents' tool successfully after reload: %v", err)
+	}
+	listContentAfter, ok := listResponseAfter.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatal("expected content to be of type TextContent after reload")
+	}
+
+	// Write output for golden file comparison - after reload (documentation_2.db)
+	goldenPathAfter := "./_golden/serve-mcp-reload-documentation-list-after.txt"
+	outputPathAfter := fmt.Sprintf("./_output/serve-mcp-reload-documentation-list-after-%d.txt", time.Now().UnixMilli())
+	err = os.WriteFile(outputPathAfter, []byte(listContentAfter.Text), 0644)
+	if err != nil {
+		t.Fatalf("expected to write output file: %v", err)
+	}
+
+	if *update {
+		updateGolden(goldenPathAfter, outputPathAfter, t)
+	}
+
+	compareFiles(goldenPathAfter, outputPathAfter, t)
+}

--- a/cli/e2e/serveMCPToolsReloadDocumentation_test.go
+++ b/cli/e2e/serveMCPToolsReloadDocumentation_test.go
@@ -11,19 +11,14 @@ import (
 )
 
 func TestServeMCPReloadDocumentation(t *testing.T) {
-	githubToken := os.Getenv("HYALINE_CONFIG_GITHUB_TOKEN")
-	githubRepo := "appgardenstudios/hyaline-example"
+	githubToken := os.Getenv("_HYALINE_TEST_GITHUB_TOKEN")
 
 	// Set initial documentation to documentation_1.db
-	dispatchWorkflow(t, githubToken, githubRepo, "set-current-documentation.yml", map[string]interface{}{
+	dispatchWorkflow(t, githubToken, "appgardenstudios/hyaline-example", "set-current-documentation.yml", map[string]interface{}{
 		"artifact_source": "documentation_1.db",
 	})
 
-	client := setupServeMCPClient(t, ServeMCPClientOptions{
-		GitHubRepo:     githubRepo,
-		GitHubArtifact: "_current-documentation",
-		GitHubToken:    githubToken,
-	})
+	client := setupServeMCPClient(t, "serve mcp --github-repo appgardenstudios/hyaline-example --github-token "+githubToken)
 	ctx := context.Background()
 
 	// 1. List documents before reload
@@ -53,7 +48,7 @@ func TestServeMCPReloadDocumentation(t *testing.T) {
 	compareFiles(goldenPathBefore, outputPathBefore, t)
 
 	// 2. Switch to documentation_2.db and reload
-	dispatchWorkflow(t, githubToken, githubRepo, "set-current-documentation.yml", map[string]interface{}{
+	dispatchWorkflow(t, githubToken, "appgardenstudios/hyaline-example", "set-current-documentation.yml", map[string]interface{}{
 		"artifact_source": "documentation_2.db",
 	})
 

--- a/cli/internal/action/auditDocumentation.go
+++ b/cli/internal/action/auditDocumentation.go
@@ -62,11 +62,12 @@ func AuditDocumentation(args *AuditDocumentationArgs) error {
 	}
 
 	// Initialize documentation database
-	db, err := sqlite.InitInput(args.Documentation)
+	db, close, err := sqlite.InitInput(args.Documentation)
 	if err != nil {
 		slog.Debug("action.AuditDocumentation could not initialize documentation database", "documentation", args.Documentation, "error", err)
 		return err
 	}
+	defer close()
 
 	slog.Debug("action.AuditDocumentation initialized documentation database", "documentation", args.Documentation)
 

--- a/cli/internal/action/checkDiff.go
+++ b/cli/internal/action/checkDiff.go
@@ -163,11 +163,12 @@ func CheckDiff(args *CheckDiffArgs) error {
 	}
 
 	// Get Documents
-	docDB, err := sqlite.InitInput(args.Documentation)
+	docDB, close, err := sqlite.InitInput(args.Documentation)
 	if err != nil {
 		slog.Debug("action.CheckDiff could not initialize documentation db", "documentation", args.Documentation, "error", err)
 		return err
 	}
+	defer close()
 	documents, err := docs.GetFilteredDocs(&cfg.Check.Documentation, docDB)
 	if err != nil {
 		slog.Debug("action.CheckDiff could not get filtered documents", "error", err)

--- a/cli/internal/action/checkPR.go
+++ b/cli/internal/action/checkPR.go
@@ -121,11 +121,12 @@ func CheckPR(args *CheckPRArgs) error {
 	}
 
 	// Get Documents
-	docDB, err := sqlite.InitInput(args.Documentation)
+	docDB, close, err := sqlite.InitInput(args.Documentation)
 	if err != nil {
 		slog.Debug("action.CheckPR could not initialize documentation db", "documentation", args.Documentation, "error", err)
 		return err
 	}
+	defer close()
 	documents, err := docs.GetFilteredDocs(&cfg.Check.Documentation, docDB)
 	if err != nil {
 		slog.Debug("action.CheckPR could not get filtered documents", "error", err)

--- a/cli/internal/action/exportDocumentation.go
+++ b/cli/internal/action/exportDocumentation.go
@@ -99,11 +99,12 @@ func ExportDocumentation(args *ExportDocumentationArgs) error {
 	}
 
 	// Open Documentation database
-	docDB, err := sqlite.InitInput(args.Documentation)
+	docDB, close, err := sqlite.InitInput(args.Documentation)
 	if err != nil {
 		slog.Debug("action.ExportDocumentation could not initialize documentation db", "documentation", args.Documentation, "error", err)
 		return err
 	}
+	defer close()
 
 	// Get documentation
 	filters := &config.CheckDocumentation{}

--- a/cli/internal/action/mergeDocumentation.go
+++ b/cli/internal/action/mergeDocumentation.go
@@ -32,11 +32,12 @@ func MergeDocumentation(args *MergeDocumentationArgs) error {
 		slog.Info(fmt.Sprintf("Merging %d of %d", i+1, len(args.Inputs)))
 
 		// Initialize input database
-		inputDB, err := sqlite.InitInput(input)
+		inputDB, close, err := sqlite.InitInput(input)
 		if err != nil {
 			slog.Debug("action.MergeDocumentation could not initialize input", "input", input, "error", err)
 			return err
 		}
+		defer close()
 
 		// Get all sources from input database
 		sources, err := inputDB.GetAllSources(ctx)

--- a/cli/internal/action/serveMCP.go
+++ b/cli/internal/action/serveMCP.go
@@ -5,6 +5,7 @@ import (
 	"hyaline/internal/github"
 	"hyaline/internal/io"
 	"hyaline/internal/serve/mcp"
+	"hyaline/internal/serve/mcp/utils"
 	"hyaline/internal/sqlite"
 	"log/slog"
 	"os"
@@ -72,7 +73,13 @@ func ServeMCP(args *ServeMCPArgs, version string) error {
 	defer close()
 
 	// Create and start MCP server
-	server, err := mcp.NewServer(db, version, args.GitHubRepo, args.GitHubArtifact, args.GitHubArtifactPath, args.GitHubToken, args.Documentation)
+	server, err := mcp.NewServer(db, version, utils.ServerOptions{
+		GitHubRepo:         args.GitHubRepo,
+		GitHubArtifact:     args.GitHubArtifact,
+		GitHubArtifactPath: args.GitHubArtifactPath,
+		GitHubToken:        args.GitHubToken,
+		DocumentationPath:  args.Documentation,
+	})
 	if err != nil {
 		slog.Debug("action.ServeMCP could not create MCP server", "error", err)
 		return err

--- a/cli/internal/github/artifacts.go
+++ b/cli/internal/github/artifacts.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-github/v74/github"
+)
+
+func DownloadLatestArtifact(githubRepo string, artifactName string, githubToken string, destDir string) (string, error) {
+	slog.Debug("github.DownloadLatestArtifact starting",
+		slog.Group("args",
+			"githubRepo", githubRepo,
+			"artifactName", artifactName,
+			"destDir", destDir,
+		),
+	)
+
+	parts := strings.Split(githubRepo, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid github repo format: %s", githubRepo)
+	}
+	owner, repo := parts[0], parts[1]
+
+	client := github.NewClient(nil).WithAuthToken(githubToken)
+	artifacts, _, err := client.Actions.ListArtifacts(context.Background(), owner, repo, &github.ListArtifactsOptions{
+		Name: &artifactName,
+		ListOptions: github.ListOptions{
+			PerPage: 1,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list artifacts: %w", err)
+	}
+
+	if len(artifacts.Artifacts) == 0 {
+		return "", fmt.Errorf("artifact not found: %s", artifactName)
+	}
+
+	targetArtifact := artifacts.Artifacts[0]
+
+	slog.Debug("github.DownloadLatestArtifact found artifact", "artifactID", targetArtifact.GetID())
+
+	downloadURL, _, err := client.Actions.DownloadArtifact(context.Background(), owner, repo, targetArtifact.GetID(), 3)
+	if err != nil {
+		return "", fmt.Errorf("failed to get artifact download URL: %w", err)
+	}
+
+	slog.Debug("github.DownloadLatestArtifact downloading artifact", "url", downloadURL.String())
+
+	req, err := http.NewRequest("GET", downloadURL.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create download request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to download artifact: %w", err)
+	}
+	defer resp.Body.Close()
+
+	zipPath := filepath.Join(destDir, "artifact.zip")
+	out, err := os.Create(zipPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create zip file: %w", err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to save zip file: %w", err)
+	}
+
+	slog.Debug("github.DownloadLatestArtifact downloaded artifact", "path", zipPath)
+
+	return zipPath, nil
+}

--- a/cli/internal/io/unzip.go
+++ b/cli/internal/io/unzip.go
@@ -1,0 +1,62 @@
+package io
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Based on https://stackoverflow.com/a/24792688
+func Unzip(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	os.MkdirAll(dest, 0755)
+
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer rc.Close()
+
+		path := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip (Directory traversal)
+		if !strings.HasPrefix(path, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path: %s", path)
+		}
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(path, f.Mode())
+		} else {
+			os.MkdirAll(filepath.Dir(path), f.Mode())
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cli/internal/serve/mcp/server.go
+++ b/cli/internal/serve/mcp/server.go
@@ -21,11 +21,11 @@ type Server struct {
 	githubArtifact     string
 	githubToken        string
 	githubArtifactPath string
-	filesystemDocPath  string
+	documentationPath  string
 }
 
 // NewServer creates and initializes a new MCP server
-func NewServer(db *sqlite.Queries, version string, githubRepo string, githubArtifact string, githubArtifactPath string, githubToken string, filesystemDocPath string) (*Server, error) {
+func NewServer(db *sqlite.Queries, version string, githubRepo string, githubArtifact string, githubArtifactPath string, githubToken string, documentationPath string) (*Server, error) {
 	slog.Debug("serve.mcp.NewServer starting")
 
 	// Load all data into memory
@@ -48,7 +48,7 @@ func NewServer(db *sqlite.Queries, version string, githubRepo string, githubArti
 		githubArtifact:     githubArtifact,
 		githubArtifactPath: githubArtifactPath,
 		githubToken:        githubToken,
-		filesystemDocPath:  filesystemDocPath,
+		documentationPath:  documentationPath,
 	}
 
 	// Register tools and prompts
@@ -73,13 +73,7 @@ func (hyalineMCPServer *Server) registerTools() {
 	})
 
 	hyalineMCPServer.mcpServer.AddTool(tools.ReloadDocumentationTool(), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Use the appropriate documentation path based on mode
-		documentationPath := hyalineMCPServer.filesystemDocPath
-		if hyalineMCPServer.githubRepo != "" {
-			documentationPath = hyalineMCPServer.githubArtifactPath
-		}
-
-		result, newDocumentationData, err := tools.HandleReloadDocumentation(ctx, request, hyalineMCPServer.githubRepo, hyalineMCPServer.githubArtifact, hyalineMCPServer.githubToken, documentationPath)
+		result, newDocumentationData, err := tools.HandleReloadDocumentation(ctx, request, hyalineMCPServer.githubRepo, hyalineMCPServer.githubArtifact, hyalineMCPServer.githubToken, hyalineMCPServer.githubArtifactPath, hyalineMCPServer.documentationPath)
 		if err != nil {
 			return result, err
 		}

--- a/cli/internal/serve/mcp/server.go
+++ b/cli/internal/serve/mcp/server.go
@@ -15,17 +15,13 @@ import (
 
 // Server represents the MCP server with in-memory data
 type Server struct {
-	mcpServer          *server.MCPServer
-	documentationData  *utils.DocumentationData
-	githubRepo         string
-	githubArtifact     string
-	githubToken        string
-	githubArtifactPath string
-	documentationPath  string
+	mcpServer         *server.MCPServer
+	documentationData *utils.DocumentationData
+	options           utils.ServerOptions
 }
 
 // NewServer creates and initializes a new MCP server
-func NewServer(db *sqlite.Queries, version string, githubRepo string, githubArtifact string, githubArtifactPath string, githubToken string, documentationPath string) (*Server, error) {
+func NewServer(db *sqlite.Queries, version string, opts utils.ServerOptions) (*Server, error) {
 	slog.Debug("serve.mcp.NewServer starting")
 
 	// Load all data into memory
@@ -42,13 +38,9 @@ func NewServer(db *sqlite.Queries, version string, githubRepo string, githubArti
 	)
 
 	hyalineMCPServer := &Server{
-		mcpServer:          mcpServer,
-		documentationData:  documentationData,
-		githubRepo:         githubRepo,
-		githubArtifact:     githubArtifact,
-		githubArtifactPath: githubArtifactPath,
-		githubToken:        githubToken,
-		documentationPath:  documentationPath,
+		mcpServer:         mcpServer,
+		documentationData: documentationData,
+		options:           opts,
 	}
 
 	// Register tools and prompts
@@ -73,7 +65,7 @@ func (hyalineMCPServer *Server) registerTools() {
 	})
 
 	hyalineMCPServer.mcpServer.AddTool(tools.ReloadDocumentationTool(), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		result, newDocumentationData, err := tools.HandleReloadDocumentation(ctx, request, hyalineMCPServer.githubRepo, hyalineMCPServer.githubArtifact, hyalineMCPServer.githubToken, hyalineMCPServer.githubArtifactPath, hyalineMCPServer.documentationPath)
+		result, newDocumentationData, err := tools.HandleReloadDocumentation(ctx, request, hyalineMCPServer.options)
 		if err != nil {
 			return result, err
 		}

--- a/cli/internal/serve/mcp/tools/reloadDocumentation.go
+++ b/cli/internal/serve/mcp/tools/reloadDocumentation.go
@@ -19,7 +19,7 @@ func ReloadDocumentationTool() mcp.Tool {
 	)
 }
 
-func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, githubRepo string, githubArtifact string, githubToken string, documentationPath string) (*mcp.CallToolResult, *utils.DocumentationData, error) {
+func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, githubRepo string, githubArtifact string, githubToken string, githubArtifactPath string, filesystemDocPath string) (*mcp.CallToolResult, *utils.DocumentationData, error) {
 	var absPath string
 
 	// If GitHub repository is configured, download from GitHub
@@ -49,11 +49,11 @@ func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, g
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to unzip artifact: %s", err.Error())), nil, nil
 		}
 
-		// Join the unzipped directory with the documentation path
-		absPath = filepath.Join(unzipDir, documentationPath)
+		// Join the unzipped directory with the GitHub artifact path
+		absPath = filepath.Join(unzipDir, githubArtifactPath)
 	} else {
 		// Use the documentation path from the filesystem
-		absPath = documentationPath
+		absPath = filesystemDocPath
 	}
 
 	// Initialize database

--- a/cli/internal/serve/mcp/tools/reloadDocumentation.go
+++ b/cli/internal/serve/mcp/tools/reloadDocumentation.go
@@ -19,13 +19,13 @@ func ReloadDocumentationTool() mcp.Tool {
 	)
 }
 
-func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, githubRepo string, githubArtifact string, githubToken string, githubArtifactPath string, filesystemDocPath string) (*mcp.CallToolResult, *utils.DocumentationData, error) {
+func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, opts utils.ServerOptions) (*mcp.CallToolResult, *utils.DocumentationData, error) {
 	var absPath string
 
 	// If GitHub repository is configured, download from GitHub
-	if githubRepo != "" {
+	if opts.GitHubRepo != "" {
 		// Check if GitHub token is configured
-		if githubToken == "" {
+		if opts.GitHubToken == "" {
 			return mcp.NewToolResultError("GitHub token is not configured."), nil, nil
 		}
 
@@ -37,7 +37,7 @@ func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, g
 		defer os.RemoveAll(tempDir)
 
 		// Download latest artifact
-		zipPath, err := github.DownloadLatestArtifact(githubRepo, githubArtifact, githubToken, tempDir)
+		zipPath, err := github.DownloadLatestArtifact(opts.GitHubRepo, opts.GitHubArtifact, opts.GitHubToken, tempDir)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to download artifact: %s", err.Error())), nil, nil
 		}
@@ -50,10 +50,10 @@ func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, g
 		}
 
 		// Join the unzipped directory with the GitHub artifact path
-		absPath = filepath.Join(unzipDir, githubArtifactPath)
+		absPath = filepath.Join(unzipDir, opts.GitHubArtifactPath)
 	} else {
 		// Use the documentation path from the filesystem
-		absPath = filesystemDocPath
+		absPath = opts.DocumentationPath
 	}
 
 	// Initialize database

--- a/cli/internal/serve/mcp/tools/reloadDocumentation.go
+++ b/cli/internal/serve/mcp/tools/reloadDocumentation.go
@@ -1,0 +1,73 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"hyaline/internal/github"
+	"hyaline/internal/io"
+	"hyaline/internal/serve/mcp/utils"
+	"hyaline/internal/sqlite"
+	"os"
+	"path/filepath"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func ReloadDocumentationTool() mcp.Tool {
+	return mcp.NewTool("reload_documentation",
+		mcp.WithDescription("Reload the documentation dataset."),
+	)
+}
+
+func HandleReloadDocumentation(_ context.Context, request mcp.CallToolRequest, githubRepo string, githubArtifact string, githubToken string, documentationPath string) (*mcp.CallToolResult, *utils.DocumentationData, error) {
+	var absPath string
+
+	// If GitHub repository is configured, download from GitHub
+	if githubRepo != "" {
+		// Check if GitHub token is configured
+		if githubToken == "" {
+			return mcp.NewToolResultError("GitHub token is not configured."), nil, nil
+		}
+
+		// Create a temporary directory
+		tempDir, err := os.MkdirTemp("", "hyaline-docs-reload-*")
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to create temp dir: %s", err.Error())), nil, nil
+		}
+		defer os.RemoveAll(tempDir)
+
+		// Download latest artifact
+		zipPath, err := github.DownloadLatestArtifact(githubRepo, githubArtifact, githubToken, tempDir)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to download artifact: %s", err.Error())), nil, nil
+		}
+
+		// Unzip the artifact
+		unzipDir := filepath.Join(tempDir, "unzipped")
+		err = io.Unzip(zipPath, unzipDir)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to unzip artifact: %s", err.Error())), nil, nil
+		}
+
+		// Join the unzipped directory with the documentation path
+		absPath = filepath.Join(unzipDir, documentationPath)
+	} else {
+		// Use the documentation path from the filesystem
+		absPath = documentationPath
+	}
+
+	// Initialize database
+	db, close, err := sqlite.InitInput(absPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to initialize database: %s", err.Error())), nil, nil
+	}
+	defer close()
+
+	// Load documentation data
+	documentationData, err := utils.LoadAllData(db)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to load data: %s", err.Error())), nil, nil
+	}
+
+	return mcp.NewToolResultText("Documentation reloaded successfully."), documentationData, nil
+}

--- a/cli/internal/serve/mcp/utils/data.go
+++ b/cli/internal/serve/mcp/utils/data.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"hyaline/internal/docs"
 	"hyaline/internal/sqlite"
@@ -31,14 +30,13 @@ type DocumentationData struct {
 }
 
 // LoadAllData loads all documentation data from the database into memory
-func LoadAllData(db *sql.DB) (*DocumentationData, error) {
+func LoadAllData(db *sqlite.Queries) (*DocumentationData, error) {
 	slog.Debug("serve.mcp.data.LoadAllData starting")
 
 	ctx := context.Background()
-	queries := sqlite.New(db)
 
 	// Load sources
-	sqliteSources, err := queries.GetAllSources(ctx)
+	sqliteSources, err := db.GetAllSources(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load sources: %w", err)
 	}
@@ -52,7 +50,7 @@ func LoadAllData(db *sql.DB) (*DocumentationData, error) {
 		}
 
 		// Load documents for this source
-		sqliteDocuments, err := queries.GetDocumentsForSource(ctx, source.ID)
+		sqliteDocuments, err := db.GetDocumentsForSource(ctx, source.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load documents for source %s: %w", source.ID, err)
 		}
@@ -67,7 +65,7 @@ func LoadAllData(db *sql.DB) (*DocumentationData, error) {
 			}
 
 			// Load document tags
-			documentTags, err := queries.GetDocumentTags(ctx, sqlite.GetDocumentTagsParams{
+			documentTags, err := db.GetDocumentTags(ctx, sqlite.GetDocumentTagsParams{
 				SourceID:   source.ID,
 				DocumentID: document.ID,
 			})
@@ -81,7 +79,7 @@ func LoadAllData(db *sql.DB) (*DocumentationData, error) {
 			}
 
 			// Load sections
-			sqliteSections, err := queries.GetSectionsForDocument(ctx, sqlite.GetSectionsForDocumentParams{
+			sqliteSections, err := db.GetSectionsForDocument(ctx, sqlite.GetSectionsForDocumentParams{
 				SourceID:   source.ID,
 				DocumentID: document.ID,
 			})
@@ -99,7 +97,7 @@ func LoadAllData(db *sql.DB) (*DocumentationData, error) {
 				}
 
 				// Load section tags
-				sectionTags, err := queries.GetSectionTags(ctx, sqlite.GetSectionTagsParams{
+				sectionTags, err := db.GetSectionTags(ctx, sqlite.GetSectionTagsParams{
 					SourceID:   source.ID,
 					DocumentID: document.ID,
 					SectionID:  section.ID,

--- a/cli/internal/serve/mcp/utils/serverOptions.go
+++ b/cli/internal/serve/mcp/utils/serverOptions.go
@@ -1,0 +1,9 @@
+package utils
+
+type ServerOptions struct {
+	GitHubRepo         string
+	GitHubArtifact     string
+	GitHubToken        string
+	GitHubArtifactPath string
+	DocumentationPath  string
+}

--- a/cli/internal/sqlite/init.go
+++ b/cli/internal/sqlite/init.go
@@ -53,7 +53,7 @@ func InitOutput(outputPath string) (q *Queries, close func() error, err error) {
 	return
 }
 
-func InitInput(inputPath string) (q *Queries, err error) {
+func InitInput(inputPath string) (q *Queries, close func() error, err error) {
 	// Get absolute path
 	absPath, err := filepath.Abs(inputPath)
 	if err != nil {
@@ -74,6 +74,7 @@ func InitInput(inputPath string) (q *Queries, err error) {
 		slog.Debug("sqlite.InitInput could not open input SQLite DB", "dataSourceName", absPath, "error", err)
 		return
 	}
+	close = db.Close
 
 	// Create sqlc queries struct
 	q = New(db)

--- a/www/content/documentation/how-to/install-github-app.md
+++ b/www/content/documentation/how-to/install-github-app.md
@@ -58,7 +58,7 @@ The following repository variables should be created in your `hyaline-github-app
 **HYALINE_LLM_MODEL** - The LLM model to be used. This will be referenced as the value for `llm.provider` in the configs (using environment substitution). Please see [configuration reference](../reference/config.md) for supported values.
 
 ### 3. Run Install
-To bootstrap the repository in preparation for the Github App installation you will need to run the `Install` workflow and review/edit/merge the generated pull request.
+To bootstrap the repository in preparation for the GitHub App installation you will need to run the `Install` workflow and review/edit/merge the generated pull request.
 
 Manually trigger the `Install` workflow in your `hyaline-github-app-config` repo instance and ensure that it completes successfully. It will run `Update Hyaline` to ensure your `hyaline-github-app-config` repo is properly connected and up-to-date. It also runs `Doctor` to generate a pull request with a set of suggested changes and configuration updates based on the repositories in scope of the `HYALINE_GITHUB_TOKEN` generated above.
 

--- a/www/content/documentation/how-to/run-mcp-server.md
+++ b/www/content/documentation/how-to/run-mcp-server.md
@@ -13,11 +13,51 @@ Run the hyaline mcp server locally.
 
 ## Steps
 
-### 1. Download Current Documentation
+The Hyaline MCP server can be run in two modes: **GitHub Artifacts mode** (recommended) or **Local Filesystem mode**.
+
+### Option 1: GitHub Artifacts Mode (Recommended)
+
+This mode automatically downloads the latest documentation from your `hyaline-github-app-config` repo instance, making it easier to keep your documentation up to date.
+
+#### 1. Create a Personal Access Token
+Create a GitHub Personal Access Token (classic) with access to read action artifacts from your `hyaline-github-app-config` repo instance.
+
+#### 2. Add MCP Server to Client
+Configure your MCP client to run the Hyaline Docker image with GitHub repository access. Here is example configuration for Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "hyaline": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "ghcr.io/appgardenstudios/hyaline:latest",
+        "serve",
+        "mcp",
+        "--github-repo",
+        "<your_github_account>/hyaline-github-app-config",
+        "--github-token",
+        "<ghp_yourpersonalaccesstoken>"
+      ]
+    }
+  }
+}
+```
+
+Replace `<your_github_account>/hyaline-github-app-config` with your actual repository path an `<ghp_yourpersonalaccesstoken>` with your personal access token.
+
+### Option 2: Local Filesystem Mode
+
+This mode uses a locally downloaded documentation database file.
+
+#### 1. Download Current Documentation
 Go to the latest `_Merge` workflow run in your `hyaline-github-app-config` repo instance and download the artifact `_current-documentation`. Once downloaded extract the folder and note the location of the extracted `documentation.db` file for later use.
 
-### 2. Add MCP Server to Client
-This will vary by client, but the gist is to configure the client to run the [Hyaline Docker image](https://github.com/appgardenstudios/hyaline/pkgs/container/hyaline), mount the documentation as a volume, and start the MCP server. Here is example configuration for configuring the Hyaline MCP server for Claude Code (substituting `<path-to-documentation.db>` with the path to the downloaded `documentation.db` on your local machine):
+#### 2. Add MCP Server to Client
+Configure your MCP client to run the Hyaline Docker image with the documentation mounted as a volume. Here is example configuration for Claude Code (substituting `<path-to-documentation.db>` with the path to the downloaded `documentation.db` on your local machine):
 
 ```json
 {
@@ -41,7 +81,7 @@ This will vary by client, but the gist is to configure the client to run the [Hy
 }
 ```
 
-Please see your client documentation for specific steps.
+Please see your MCP client documentation for specific configuration steps.
 
 ## Next Steps
 Read more about [Hyaline's MCP server](../explanation/mcp.md) or visit the [CLI reference](../reference/cli.md).

--- a/www/content/documentation/reference/cli.md
+++ b/www/content/documentation/reference/cli.md
@@ -146,7 +146,7 @@ Merge multiple documentation databases `./docs1.db`, `./docs2.db`, and `./docs3.
 * `--github-repo` - The path of the hyaline-github-app-config repo in GitHub (e.g. `owner/repo`). When set, downloads documentation from GitHub artifacts. Either `--documentation` or `--github-repo` is required.
 * `--github-artifact` - The name of the documentation artifact in the hyaline-github-app-config repo. Defaults to `_current-documentation`.
 * `--github-artifact-path` - The path to the SQLite database within the GitHub artifact. Defaults to `documentation.db`.
-* `--github-token` - A GitHub Personal Access Token to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`. Can also be set via the `HYALINE_CONFIG_GITHUB_TOKEN` environment variable.
+* `--github-token` - A GitHub Personal Access Token to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`. Consider setting this using an environment variable (e.g. `--github-token $HYALINE_SERVE_MCP_GITHUB_TOKEN`).
 
 **Example (local filesystem)**:
 ```
@@ -156,7 +156,7 @@ Start a local MCP server using the standard I/O transport and have it use the ex
 
 **Example (GitHub artifacts)**:
 ```
-$ hyaline serve mcp --github-repo appgardenstudios/hyaline-example --github-token $HYALINE_CONFIG_GITHUB_TOKEN
+$ hyaline serve mcp --github-repo appgardenstudios/hyaline-example --github-token $HYALINE_SERVE_MCP_GITHUB_TOKEN
 ```
 Start a local MCP server that downloads and serves documentation from GitHub artifacts in the `appgardenstudios/hyaline-example` repository.
 

--- a/www/content/documentation/reference/cli.md
+++ b/www/content/documentation/reference/cli.md
@@ -142,13 +142,25 @@ Merge multiple documentation databases `./docs1.db`, `./docs2.db`, and `./docs3.
 `hyaline serve mcp` starts an MCP server running locally over stdio and serves up the documentation produced by running `hyaline extract documentation`.
 
 **Options**:
-* `--documentation` - (required) Path to the SQLite database containing documentation
+* `--documentation` - Path to the SQLite database containing documentation. Required when `--github-repo` is not set.
+* `--github-repo` - The path of the hyaline-github-app-config repo in GitHub (e.g. `owner/repo`). When set, downloads documentation from GitHub artifacts. Either `--documentation` or `--github-repo` is required.
+* `--github-artifact` - The name of the documentation artifact in the hyaline-github-app-config repo. Defaults to `_current-documentation`.
+* `--github-artifact-path` - The path to the SQLite database within the GitHub artifact. Defaults to `documentation.db`.
+* `--github-token` - A GitHub Personal Access Tokenccess to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`. Can also be set via the `HYALINE_CONFIG_GITHUB_TOKEN` environment variable.
 
-**Example**:
+**Example (local filesystem)**:
 ```
 $ hyaline serve mcp --documentation ./documentation.db
 ```
 Start a local MCP server using the standard I/O transport and have it use the extracted documentation found in `./documentation.db`.
+
+**Example (GitHub artifacts)**:
+```
+$ hyaline serve mcp --github-repo appgardenstudios/hyaline-example --github-token $HYALINE_CONFIG_GITHUB_TOKEN
+```
+Start a local MCP server that downloads and serves documentation from GitHub artifacts in the `appgardenstudios/hyaline-example` repository.
+
+See the explanation about the [GitHub App](../explanation/github-app.md) for more details.
 
 ## export documentation
 `hyaline export documentation` exports documentation from a documentation data set. Please see the explanation for [export](../explanation/export.md) for more details.

--- a/www/content/documentation/reference/cli.md
+++ b/www/content/documentation/reference/cli.md
@@ -146,7 +146,7 @@ Merge multiple documentation databases `./docs1.db`, `./docs2.db`, and `./docs3.
 * `--github-repo` - The path of the hyaline-github-app-config repo in GitHub (e.g. `owner/repo`). When set, downloads documentation from GitHub artifacts. Either `--documentation` or `--github-repo` is required.
 * `--github-artifact` - The name of the documentation artifact in the hyaline-github-app-config repo. Defaults to `_current-documentation`.
 * `--github-artifact-path` - The path to the SQLite database within the GitHub artifact. Defaults to `documentation.db`.
-* `--github-token` - A GitHub Personal Access Tokenccess to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`. Can also be set via the `HYALINE_CONFIG_GITHUB_TOKEN` environment variable.
+* `--github-token` - A GitHub Personal Access Token to read action artifacts from the hyaline-github-app-config repo. Required when using `--github-repo`. Can also be set via the `HYALINE_CONFIG_GITHUB_TOKEN` environment variable.
 
 **Example (local filesystem)**:
 ```

--- a/www/content/documentation/reference/mcp.md
+++ b/www/content/documentation/reference/mcp.md
@@ -28,6 +28,15 @@ Get the contents of documents matching the specified URI, or all documents if no
 **Output**
 One or more documents (including the contents of each document).
 
+### reload_documentation
+Reload the documentation dataset. When running in GitHub Artifacts mode (with `--github-repo`), this downloads the latest artifact from the configured repository. When running in local filesystem mode (with `--documentation`), this reloads the documentation from the local database file.
+
+**Arguments**
+None.
+
+**Output**
+A success message indicating the documentation was reloaded successfully.
+
 ## Prompts
 <!-- Document all the available prompts the Hyaline MCP server provides -->
 Hyaline's MCP server provides the following prompts:


### PR DESCRIPTION
# Purpose
The purpose of this change is to add support for pulling documentation from the hyaline-github-app-config repo instance. See #323 

# Changes
- Added CLI arguments to configure the MCP server to pull down documentation from a repo's artifacts
- Refactored some existing code to ensure we are closing input databases
- Updated documenation
- Added e2e tests and launch configuration

# Testing
- Run e2e tests and/or the launch configuration
- Build hyaline locally and follow the steps in the "run MCP server" documentation to point at the hyaline-github-app-config-internal repo