### PR TITLE
Marketing - Try it Free

### DIFF
--- a/www/content/documentation/getting-started.md
+++ b/www/content/documentation/getting-started.md
@@ -1,23 +1,24 @@
 ---
 title: "Getting Started with Hyaline"
-description: "Quick guide to install Hyaline, create configuration, extract documentation, and set up an MCP integration."
-purpose: Document how to get started with Hyaline
+description: "A breakdown of the ways to get started with Hyaline, including setting Hyaline up on a single repo, installing the GitHub App, and using Hyaline from scratch."
+purpose: Document how to get started with Hyaline, including informing potential customers that they can try Hyaline for free.
 ---
 Welcome to Hyaline (pronounced "HIGH-uh-leen"), a documentation tool that helps software development teams keep their documentation current, accurate, and accessible. This guide will walk you through setting up Hyaline.
 
 ## Prerequisites
 - One or more documentation sources (e.g. git repo, filesystem directory, website)
 - A GitHub account OR a supported operating system (64-bit Linux, macOS, or Windows)
-- A [supported LLM Provider](./llms/)
+- A [supported LLM Provider](./llms/). Note: several LLM providers, including GitHub Models, offer a generous free tier.
 
-> Please note that you are free to install and use Hyaline without a license for testing and evaluation purposes. You will need to [obtain a license](/#pricing) to use Hyaline for any other purpose.
+## Free to Try
+You can use Hyaline without a license for evaluation and demonstration purposes. Simply follow the setup instructions below. When you are done with your evaluation, you will need to [obtain a license](/#pricing).
 
-## Try it Out
-If you just want to try out Hyaline, please see [How To Try Out Hyaline](./how-to/try-out-hyaline.md). This will guide you through the steps needed to try out Hyaline in a single repository using the free tier of the GitHub Models LLM.
+## Quick Start (Single Repository)
+If you want to quickly try Hyaline on just one of your repositories, see [How To Try Out Hyaline](./how-to/try-out-hyaline.md). This guide walks you through setting up Hyaline on a single repository using the free tier of the GitHub Models LLM.
 
-Note that this is not the recommended installation method, as it will only check documentation in a single repository and will not create or use a centralized set of documentation to keep up-to-date. To unlock the full utility of Hyaline please [Install the GitHub App](./how-to/install-github-app.md).
+**Note:** While this is the fastest way to try out Hyaline, it only checks documentation in a single repository and doesn't create a centralized set of documentation. To experience Hyaline's full capabilities, we recommend installing the GitHub App (see below).
 
-## Install the GitHub App
+## Install the GitHub App (Recommended)
 The [Hyaline GitHub App](https://github.com/apps/hyaline-dev) is the recommended way to use Hyaline. It uses a configuration repository in your organization or personal account to extract, check, and audit documentation. To install the Hyaline GitHub App please see [How To: Install the GitHub App](./how-to/install-github-app.md).
 
 Once installed you can visit other How To guides to learn how to [extract documentation](./how-to/extract-documentation.md), [check pull requests](./how-to/check-pull-request.md), or [run an MCP server](./how-to/run-mcp-server.md). Alternatively you can [learn more about how hyaline works](./explanation/hyaline.md) or visit the [configuration reference](./reference/config.md) to learn how to configure Hyaline.

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -45,7 +45,7 @@
             <a
               href="/documentation/getting-started/"
               class="border-2 border-blue-600 text-blue-600 px-4 py-2 rounded-md hover:bg-blue-600 hover:text-white transition-colors font-medium"
-              >Get Started</a
+              >Try it Free</a
             >
           </nav>
           <div class="md:hidden">
@@ -108,7 +108,7 @@
             <a
               href="/documentation/getting-started/"
               class="block px-3 py-2 rounded-md text-base font-medium border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white transition-colors text-center"
-              >Get Started</a
+              >Try it Free</a
             >
           </div>
         </div>
@@ -117,7 +117,7 @@
 
     <main>{{ block "main" . }} {{ end }}</main>
 
-    <footer class="bg-gray-100 py-8 bg-white border-t border-gray-200">
+    <footer class="bg-white py-8 border-t border-gray-200">
       <div class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between items-center">
           <p class="text-gray-600">

--- a/www/layouts/index.html
+++ b/www/layouts/index.html
@@ -9,7 +9,7 @@
         <div class="text-md md:text-lg text-gray-700 max-w-lg">
           Hyaline uses AI to detect when code changes require documentation updates, ensures your documentation remains compliant, extracts documentation from any source, and delivers your documentation where it's needed.
         </div>
-        <a href="/documentation/getting-started/" class="inline-block mt-6 px-6 py-3 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 transition-colors">Get Started</a>
+        <a href="/documentation/getting-started/" class="inline-block mt-6 px-6 py-3 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 transition-colors">Try it Free</a>
       </div>
       <div class="flex-1 w-full ">
         <div class="mx-auto w-full max-w-xl">

--- a/www/layouts/index.html
+++ b/www/layouts/index.html
@@ -107,6 +107,15 @@
           Annual
         </button>
       </div>
+      <p class="mt-5 text-sm">
+        Not ready to purchase?
+        <a
+          href="/documentation/getting-started/"
+          class="underline"
+        >
+          Try Hyaline for free.
+        </a>
+      </p>
     </div>
 
     <div


### PR DESCRIPTION
# Purpose
The purpose of this change is to add "Try it Free" CTAs on www and help users understand how to try hyaline for free. See #331 

# Changes
- Changed "Getting Started" button to "Try it Free"
- Added a "Not ready to purchase?" CTA in the pricing section
- Updated the "Getting Started" page to make sure people know they can use Hyaline for free

# Testing
- Pull down changes and start www.
- Verify the changes